### PR TITLE
Fix Precedence Of Query Expression

### DIFF
--- a/src/main/java/de/numcodex/sq2cql/PrintContext.java
+++ b/src/main/java/de/numcodex/sq2cql/PrintContext.java
@@ -13,6 +13,10 @@ public record PrintContext(int indent, int precedence) {
         return " ".repeat(indent);
     }
 
+    public String parenthesizeZero(String s) {
+        return parenthesize(0, s);
+    }
+
     public String parenthesize(int precedence, String s) {
         return precedence < this.precedence ? "(%s)".formatted(s) : s;
     }
@@ -25,6 +29,11 @@ public record PrintContext(int indent, int precedence) {
         return new PrintContext(indent, precedence);
     }
 
+    /**
+     * Sets the {@link #precedence} to zero and keeps the {@link #indent}.
+     *
+     * @return a new {@code PrintContext} with a {@code precedence} of zero and an {@code indent} of this {@code PrintContext}
+     */
     public PrintContext resetPrecedence() {
         return new PrintContext(indent, 0);
     }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/ExpressionDefinition.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/ExpressionDefinition.java
@@ -20,6 +20,7 @@ public record ExpressionDefinition(String identifier, Expression expression) imp
     }
 
     public String print(PrintContext printContext) {
+        assert printContext.precedence() == 0;
         var newPrintContext = printContext.increase();
         return "define %s:\n%s%s".formatted(identifier, newPrintContext.getIndent(),
                 expression.print(newPrintContext));

--- a/src/main/java/de/numcodex/sq2cql/model/cql/OverlapsIntervalOperatorPhrase.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/OverlapsIntervalOperatorPhrase.java
@@ -8,20 +8,22 @@ public record OverlapsIntervalOperatorPhrase(Expression leftInterval,
                                              Expression rightInterval) implements
         BooleanExpression {
 
+  public static final int PRECEDENCE = 7;
+
   public OverlapsIntervalOperatorPhrase {
     requireNonNull(leftInterval);
     requireNonNull(rightInterval);
   }
 
   public static OverlapsIntervalOperatorPhrase of(Expression leftInterval,
-      Expression rightInterval) {
+                                                  Expression rightInterval) {
     return new OverlapsIntervalOperatorPhrase(leftInterval, rightInterval);
   }
 
   @Override
   public String print(PrintContext printContext) {
-    return "%s overlaps %s".formatted(leftInterval.print(printContext),
-        rightInterval.print(printContext));
+    var operatorPrintContext = printContext.withPrecedence(PRECEDENCE);
+    return printContext.parenthesize(PRECEDENCE, "%s overlaps %s".formatted(leftInterval.print(operatorPrintContext),
+            rightInterval.print(operatorPrintContext)));
   }
-
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
@@ -17,8 +17,9 @@ public record QueryExpression(SourceClause sourceClause, WhereClause whereClause
 
     @Override
     public String print(PrintContext printContext) {
-        var wherePrintContext = printContext.increase();
-        return "%s\n%s%s".formatted(sourceClause.toCql(printContext.resetPrecedence()), wherePrintContext.getIndent(),
-                whereClause.toCql(wherePrintContext));
+        var sourcePrintContext = printContext.resetPrecedence();
+        var wherePrintContext = sourcePrintContext.increase();
+        return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.toCql(sourcePrintContext),
+                wherePrintContext.getIndent(), whereClause.toCql(wherePrintContext)));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
@@ -17,7 +17,7 @@ public record RetrieveExpression(String resourceType, Expression terminology) im
 
     @Override
     public String print(PrintContext printContext) {
-        return "[%s: %s]".formatted(resourceType, terminology.print(printContext));
+        return "[%s: %s]".formatted(resourceType, terminology.print(printContext.resetPrecedence()));
     }
 
     public IdentifierExpression alias() {

--- a/src/main/java/de/numcodex/sq2cql/model/cql/SourceClause.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/SourceClause.java
@@ -4,10 +4,10 @@ import de.numcodex.sq2cql.PrintContext;
 
 import static java.util.Objects.requireNonNull;
 
-public record SourceClause(Expression retrieve, IdentifierExpression alias) {
+public record SourceClause(Expression querySource, IdentifierExpression alias) {
 
     public SourceClause {
-        requireNonNull(retrieve);
+        requireNonNull(querySource);
         requireNonNull(alias);
     }
 
@@ -16,6 +16,7 @@ public record SourceClause(Expression retrieve, IdentifierExpression alias) {
     }
 
     public String toCql(PrintContext printContext) {
-        return "from %s %s".formatted(retrieve.print(printContext), alias.print(printContext));
+        assert printContext.precedence() == 0;
+        return "from %s %s".formatted(querySource.print(printContext), alias.print(printContext));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/TypeExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/TypeExpression.java
@@ -19,7 +19,7 @@ public record TypeExpression(Expression expression, String typeSpecifier) implem
 
     @Override
     public String print(PrintContext printContext) {
-        return printContext.parenthesize(PRECEDENCE, "%s as %s".formatted(this.expression.print(printContext
+        return printContext.parenthesize(PRECEDENCE, "%s as %s".formatted(expression.print(printContext
                 .withPrecedence(PRECEDENCE)), typeSpecifier));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/WhereClause.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/WhereClause.java
@@ -15,6 +15,7 @@ public record WhereClause(Expression expression) {
     }
 
     public String toCql(PrintContext printContext) {
-        return "where " + expression.print(printContext.resetPrecedence().increase());
+        assert printContext.precedence() == 0;
+        return "where " + expression.print(printContext.increase());
     }
 }

--- a/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
+++ b/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
@@ -238,9 +238,9 @@ class TranslatorTest {
             context Patient
                             
             define InInitialPopulation:
-              exists from [Condition: Code 'C71.1' from icd10] C
+              exists (from [Condition: Code 'C71.1' from icd10] C
                 where C.onset as dateTime in Interval[@2020-01-01T, @2020-01-02T] or
-                  C.onset overlaps Interval[@2020-01-01T, @2020-01-02T]
+                  C.onset overlaps Interval[@2020-01-01T, @2020-01-02T])
             """, library.print(PrintContext.ZERO));
   }
 
@@ -284,26 +284,26 @@ class TranslatorTest {
     Library library = Translator.of(mappingContext).toCql(structuredQuery);
 
     assertEquals("""
-        library Retrieve
-        using FHIR version '4.0.0'
-        include FHIRHelpers version '4.0.0'
+            library Retrieve
+            using FHIR version '4.0.0'
+            include FHIRHelpers version '4.0.0'
 
-        codesystem atc: 'http://fhir.de/CodeSystem/dimdi/atc'
-        codesystem icd10: 'http://fhir.de/CodeSystem/dimdi/icd-10-gm'
-        codesystem loinc: 'http://loinc.org'
-        codesystem ver_status: 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
+            codesystem atc: 'http://fhir.de/CodeSystem/dimdi/atc'
+            codesystem icd10: 'http://fhir.de/CodeSystem/dimdi/icd-10-gm'
+            codesystem loinc: 'http://loinc.org'
+            codesystem ver_status: 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
 
-        context Patient
+            context Patient
 
-        define InInitialPopulation:
-          (exists from [Condition: Code 'C71.0' from icd10] C
-            where C.verificationStatus.coding contains Code 'confirmed' from ver_status or
-          exists from [Condition: Code 'C71.1' from icd10] C
-            where C.verificationStatus.coding contains Code 'confirmed' from ver_status) and
-          exists from [Observation: Code '26515-7' from loinc] O
-            where O.value as Quantity < 50 'g/dl' and
-          exists [MedicationStatement: Code 'L01AX03' from atc]
-        """, library.print(PrintContext.ZERO));
+            define InInitialPopulation:
+              (exists (from [Condition: Code 'C71.0' from icd10] C
+                where C.verificationStatus.coding contains Code 'confirmed' from ver_status) or
+              exists (from [Condition: Code 'C71.1' from icd10] C
+                where C.verificationStatus.coding contains Code 'confirmed' from ver_status)) and
+              exists (from [Observation: Code '26515-7' from loinc] O
+                where O.value as Quantity < 50 'g/dl') and
+              exists [MedicationStatement: Code 'L01AX03' from atc]
+            """, library.print(PrintContext.ZERO));
   }
 
   @Test
@@ -327,29 +327,29 @@ class TranslatorTest {
     Library library = Translator.of(mappingContext).toCql(structuredQuery);
 
     assertEquals("""
-        library Retrieve
-        using FHIR version '4.0.0'
-        include FHIRHelpers version '4.0.0'
+            library Retrieve
+            using FHIR version '4.0.0'
+            include FHIRHelpers version '4.0.0'
 
-        codesystem atc: 'http://fhir.de/CodeSystem/dimdi/atc'
-        codesystem icd10: 'http://fhir.de/CodeSystem/dimdi/icd-10-gm'
-        codesystem sample: 'https://fhir.bbmri.de/CodeSystem/SampleMaterialType'
-        codesystem ver_status: 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
-                        
-        context Patient
+            codesystem atc: 'http://fhir.de/CodeSystem/dimdi/atc'
+            codesystem icd10: 'http://fhir.de/CodeSystem/dimdi/icd-10-gm'
+            codesystem sample: 'https://fhir.bbmri.de/CodeSystem/SampleMaterialType'
+            codesystem ver_status: 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
+                            
+            context Patient
 
-        define Inclusion:
-          exists from [Condition: Code 'I10' from icd10] C
-            where C.verificationStatus.coding contains Code 'confirmed' from ver_status and
-          exists [Specimen: Code 'Serum' from sample]
+            define Inclusion:
+              exists (from [Condition: Code 'I10' from icd10] C
+                where C.verificationStatus.coding contains Code 'confirmed' from ver_status) and
+              exists [Specimen: Code 'Serum' from sample]
 
-        define Exclusion:
-          exists [MedicationStatement: Code 'C10AA' from atc]
+            define Exclusion:
+              exists [MedicationStatement: Code 'C10AA' from atc]
 
-        define InInitialPopulation:
-          Inclusion and
-          not Exclusion
-        """, library.print(PrintContext.ZERO));
+            define InInitialPopulation:
+              Inclusion and
+              not Exclusion
+            """, library.print(PrintContext.ZERO));
   }
 
   @Test
@@ -373,34 +373,34 @@ class TranslatorTest {
     Library library = Translator.of(mappingContext).toCql(structuredQuery);
 
     assertEquals("""
-        library Retrieve
-        using FHIR version '4.0.0'
-        include FHIRHelpers version '4.0.0'
+            library Retrieve
+            using FHIR version '4.0.0'
+            include FHIRHelpers version '4.0.0'
 
-        codesystem frailty-score: 'https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score'
-        codesystem icd10: 'http://fhir.de/CodeSystem/dimdi/icd-10-gm'
-        codesystem loinc: 'http://loinc.org'
-        codesystem snomed: 'http://snomed.info/sct'
-        codesystem ver_status: 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
-                        
-        context Patient
-                        
-        define Inclusion:
-          exists from [Observation: Code '713636003' from snomed] O
-            where O.value.coding contains Code '1' from frailty-score or
-              O.value.coding contains Code '2' from frailty-score
-                        
-        define Exclusion:
-          exists from [Condition: Code '13645005' from snomed] C
-            where C.verificationStatus.coding contains Code 'confirmed' from ver_status and
-          exists from [Condition: Code 'G47.31' from icd10] C
-            where C.verificationStatus.coding contains Code 'confirmed' from ver_status or
-          exists from [Observation: Code '72166-2' from loinc] O
-            where O.value.coding contains Code 'LA18976-3' from loinc
-                        
-        define InInitialPopulation:
-          Inclusion and
-          not Exclusion
-        """, library.print(PrintContext.ZERO));
+            codesystem frailty-score: 'https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score'
+            codesystem icd10: 'http://fhir.de/CodeSystem/dimdi/icd-10-gm'
+            codesystem loinc: 'http://loinc.org'
+            codesystem snomed: 'http://snomed.info/sct'
+            codesystem ver_status: 'http://terminology.hl7.org/CodeSystem/condition-ver-status'
+                            
+            context Patient
+                            
+            define Inclusion:
+              exists (from [Observation: Code '713636003' from snomed] O
+                where O.value.coding contains Code '1' from frailty-score or
+                  O.value.coding contains Code '2' from frailty-score)
+                            
+            define Exclusion:
+              exists (from [Condition: Code '13645005' from snomed] C
+                where C.verificationStatus.coding contains Code 'confirmed' from ver_status) and
+              exists (from [Condition: Code 'G47.31' from icd10] C
+                where C.verificationStatus.coding contains Code 'confirmed' from ver_status) or
+              exists (from [Observation: Code '72166-2' from loinc] O
+                where O.value.coding contains Code 'LA18976-3' from loinc)
+                            
+            define InInitialPopulation:
+              Inclusion and
+              not Exclusion
+            """, library.print(PrintContext.ZERO));
   }
 }

--- a/src/test/java/de/numcodex/sq2cql/model/cql/ExpressionDefinitionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/ExpressionDefinitionTest.java
@@ -1,0 +1,21 @@
+package de.numcodex.sq2cql.model.cql;
+
+import de.numcodex.sq2cql.PrintContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExpressionDefinitionTest {
+
+    @Test
+    void print_query() {
+        var expr = ExpressionDefinition.of("foo", QueryExpressionTest.query());
+
+        var s = expr.print(PrintContext.ZERO);
+
+        assertEquals("""
+                define foo:
+                  from [Observation: Code '85354-9' from loinc] O
+                    where true""", s);
+    }
+}

--- a/src/test/java/de/numcodex/sq2cql/model/cql/QueryExpressionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/QueryExpressionTest.java
@@ -1,0 +1,37 @@
+package de.numcodex.sq2cql.model.cql;
+
+import de.numcodex.sq2cql.PrintContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class QueryExpressionTest {
+
+    @Test
+    void print_standalone() {
+        var expr = query();
+
+        var s = expr.print(PrintContext.ZERO);
+
+        assertEquals("""
+                from [Observation: Code '85354-9' from loinc] O
+                  where true""", s);
+    }
+
+    @Test
+    void print_inside_exists() {
+        var expr = ExistsExpression.of(query());
+
+        var s = expr.print(PrintContext.ZERO);
+
+        assertEquals("""
+                exists (from [Observation: Code '85354-9' from loinc] O
+                  where true)""", s);
+    }
+
+    static QueryExpression query() {
+        var retrieve = RetrieveExpression.of("Observation", CodeSelector.of("85354-9", "loinc"));
+        var sourceClause = SourceClause.of(retrieve, IdentifierExpression.of("O"));
+        return QueryExpression.of(sourceClause, WhereClause.of(BooleanExpression.TRUE));
+    }
+}

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptCriterionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptCriterionTest.java
@@ -219,8 +219,8 @@ class ConceptCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Condition: Code 'C71' from icd10] C
-                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status""",
+                        exists (from [Condition: Code 'C71' from icd10] C
+                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF, VER_STATUS_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -239,10 +239,10 @@ class ConceptCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Condition: Code 'C71.1' from icd10] C
-                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status or
-                        exists from [Condition: Code 'C71.2' from icd10] C
-                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status""",
+                        exists (from [Condition: Code 'C71.1' from icd10] C
+                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status) or
+                        exists (from [Condition: Code 'C71.2' from icd10] C
+                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF, VER_STATUS_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -261,8 +261,8 @@ class ConceptCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Observation: Code '85354-9' from loinc] O
-                          where O.component.where(code.coding.exists(system = 'http://loinc.org' and code = '8462-4')).value.first() as Quantity < 80 'mm[Hg]'""",
+                        exists (from [Observation: Code '85354-9' from loinc] O
+                          where O.component.where(code.coding.exists(system = 'http://loinc.org' and code = '8462-4')).value.first() as Quantity < 80 'mm[Hg]')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -278,8 +278,8 @@ class ConceptCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Procedure: Code '277132007' from snomed] P
-                          where P.status in { 'completed', 'in-progress' }""",
+                        exists (from [Procedure: Code '277132007' from snomed] P
+                          where P.status in { 'completed', 'in-progress' })""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -294,8 +294,8 @@ class ConceptCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Condition: Code 'C71' from icd10] C
-                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status""",
+                        exists (from [Condition: Code 'C71' from icd10] C
+                          where C.verificationStatus.coding contains Code 'confirmed' from ver_status)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(ICD10_CODE_SYSTEM_DEF, VER_STATUS_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/NumericCriterionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/NumericCriterionTest.java
@@ -110,8 +110,8 @@ class NumericCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '26515-7' from loinc] O
-                          where O.value as Quantity < 50 'g/dl'""",
+                        exists (from [Observation: Code '26515-7' from loinc] O
+                          where O.value as Quantity < 50 'g/dl')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -123,8 +123,8 @@ class NumericCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '06' from ecrf] O
-                          where O.value as Quantity = 6""",
+                        exists (from [Observation: Code '06' from ecrf] O
+                          where O.value as Quantity = 6)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(ECRF_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -136,8 +136,8 @@ class NumericCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code 'other-value-path' from foo] O
-                          where O.other as Quantity = 1""",
+                        exists (from [Observation: Code 'other-value-path' from foo] O
+                          where O.other as Quantity = 1)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(FOO_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -150,9 +150,9 @@ class NumericCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '06' from ecrf] O
+                        exists (from [Observation: Code '06' from ecrf] O
                           where O.value as Quantity = 6 and
-                            O.status = 'final'""",
+                            O.status = 'final')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(ECRF_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -168,9 +168,9 @@ class NumericCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Observation: Code '06' from ecrf] O
+                        exists (from [Observation: Code '06' from ecrf] O
                           where O.value as Quantity = 6 and
-                            O.status = 'final'""",
+                            O.status = 'final')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(ECRF_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/RangeCriterionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/RangeCriterionTest.java
@@ -99,8 +99,8 @@ class RangeCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '26515-7' from loinc] O
-                          where O.value as Quantity between 20 'g/dl' and 30 'g/dl'""",
+                        exists (from [Observation: Code '26515-7' from loinc] O
+                          where O.value as Quantity between 20 'g/dl' and 30 'g/dl')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -112,8 +112,8 @@ class RangeCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code 'other-value-path' from foo] O
-                          where O.other as Quantity between 1 and 2""",
+                        exists (from [Observation: Code 'other-value-path' from foo] O
+                          where O.other as Quantity between 1 and 2)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(FOO_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -126,9 +126,9 @@ class RangeCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '26515-7' from loinc] O
+                        exists (from [Observation: Code '26515-7' from loinc] O
                           where O.value as Quantity between 20 'g/dl' and 30 'g/dl' and
-                            O.status = 'final'""",
+                            O.status = 'final')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -144,9 +144,9 @@ class RangeCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Observation: Code '26515-7' from loinc] O
+                        exists (from [Observation: Code '26515-7' from loinc] O
                           where O.value as Quantity between 20 'g/dl' and 30 'g/dl' and
-                            O.status = 'final'""",
+                            O.status = 'final')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/ValueSetCriterionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/ValueSetCriterionTest.java
@@ -266,8 +266,8 @@ class ValueSetCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '94500-6' from loinc] O
-                          where O.value.coding contains Code 'positive' from snomed""",
+                        exists (from [Observation: Code '94500-6' from loinc] O
+                          where O.value.coding contains Code 'positive' from snomed)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -279,10 +279,10 @@ class ValueSetCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '21908-9' from loinc] O
-                          where O.value.coding contains Code 'LA3649-6' from loinc or
-                        exists from [Observation: Code '21902-2' from loinc] O
-                          where O.value.coding contains Code 'LA3649-6' from loinc""",
+                        exists (from [Observation: Code '21908-9' from loinc] O
+                          where O.value.coding contains Code 'LA3649-6' from loinc) or
+                        exists (from [Observation: Code '21902-2' from loinc] O
+                          where O.value.coding contains Code 'LA3649-6' from loinc)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -294,9 +294,9 @@ class ValueSetCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '76689-9' from loinc] O
+                        exists (from [Observation: Code '76689-9' from loinc] O
                           where O.value.coding contains Code 'male' from gender or
-                            O.value.coding contains Code 'female' from gender""",
+                            O.value.coding contains Code 'female' from gender)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, GENDER_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -308,8 +308,8 @@ class ValueSetCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Condition: Code '404684003' from snomed] C
-                          where C.severity.coding contains Code '24484000' from snomed""",
+                        exists (from [Condition: Code '404684003' from snomed] C
+                          where C.severity.coding contains Code '24484000' from snomed)""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -322,9 +322,9 @@ class ValueSetCriterionTest {
         var container = criterion.toCql(MAPPING_CONTEXT);
 
         assertEquals("""
-                        exists from [Observation: Code '94500-6' from loinc] O
+                        exists (from [Observation: Code '94500-6' from loinc] O
                           where O.value.coding contains Code 'positive' from snomed and
-                            O.status = 'final'""",
+                            O.status = 'final')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }
@@ -340,9 +340,9 @@ class ValueSetCriterionTest {
         var container = criterion.toCql(mappingContext);
 
         assertEquals("""
-                        exists from [Observation: Code '94500-6' from loinc] O
+                        exists (from [Observation: Code '94500-6' from loinc] O
                           where O.value.coding contains Code 'positive' from snomed and
-                            O.status = 'final'""",
+                            O.status = 'final')""",
                 PrintContext.ZERO.print(container));
         assertEquals(Set.of(LOINC_CODE_SYSTEM_DEF, SNOMED_CODE_SYSTEM_DEF), container.getCodeSystemDefinitions());
     }


### PR DESCRIPTION
The query expression has a precedence of zero and so has to be covered by parentheses if it is used in higher precedence contexts like the exists operator.