### PR TITLE
To support codes via reference i.e. MedicationAdministration which

### DIFF
--- a/src/main/java/de/numcodex/sq2cql/Container.java
+++ b/src/main/java/de/numcodex/sq2cql/Container.java
@@ -3,6 +3,7 @@ package de.numcodex.sq2cql;
 import de.numcodex.sq2cql.model.cql.AndExpression;
 import de.numcodex.sq2cql.model.cql.BooleanExpression;
 import de.numcodex.sq2cql.model.cql.CodeSystemDefinition;
+import de.numcodex.sq2cql.model.cql.Expression;
 import de.numcodex.sq2cql.model.cql.ExpressionDefinition;
 import de.numcodex.sq2cql.model.cql.OrExpression;
 
@@ -14,139 +15,179 @@ import java.util.function.Function;
 import static java.util.Objects.requireNonNull;
 
 /**
- * A container holds an expression together with the code system definitions it uses.
+ * A container holds an expression, all its referenced definitions and the code system definitions
+ * used by them.
  * <p>
- * Containers can be {@link #combiner combined}, collecting all code system definitions the individual contains use.
+ * Containers can be {@link #combiner combined}, collecting all code system definitions the
+ * individual contains use.
  * <p>
  * Instances are immutable.
  *
  * @author Alexander Kiel
  */
-public final class Container<T> {
+public final class Container<T extends Expression> {
 
-    private static final Container<?> EMPTY = new Container<>(null, Set.of(), Set.of());
-    public static final BinaryOperator<Container<BooleanExpression>> AND = combiner(AndExpression::of);
-    public static final BinaryOperator<Container<BooleanExpression>> OR = combiner(OrExpression::of);
-    private final T expression;
-    private final Set<CodeSystemDefinition> codeSystemDefinitions;
-    private final Set<ExpressionDefinition> referencedDefinitions;
+  private static final Container<?> EMPTY = new Container<>(null, Set.of(), Set.of());
+  public static final BinaryOperator<Container<BooleanExpression>> AND = combiner(
+      AndExpression::of);
+  public static final BinaryOperator<Container<BooleanExpression>> OR = combiner(OrExpression::of);
+  private final T expression;
+  private final Set<CodeSystemDefinition> codeSystemDefinitions;
+  private final Set<ExpressionDefinition> referencedDefinitions;
 
-    private Container(T expression, Set<CodeSystemDefinition> codeSystemDefinitions, Set<ExpressionDefinition> referencedDefinitions) {
-        this.expression = expression;
-        this.codeSystemDefinitions = codeSystemDefinitions;
-        this.referencedDefinitions = referencedDefinitions;
+  private Container(T expression, Set<CodeSystemDefinition> codeSystemDefinitions,
+      Set<ExpressionDefinition> referencedDefinitions) {
+    this.expression = expression;
+    this.codeSystemDefinitions = codeSystemDefinitions;
+    this.referencedDefinitions = referencedDefinitions;
+  }
+
+  /**
+   * Returns the empty container that contains no expression and no code system definitions.
+   * <p>
+   * The empty container is the identity element of the binary {@link #combiner combine} operation.
+   *
+   * @param <T> the type of the expression
+   * @return the empty container
+   */
+  public static <T extends Expression> Container<T> empty() {
+    @SuppressWarnings("unchecked")
+    Container<T> empty = (Container<T>) EMPTY;
+    return empty;
+  }
+
+  /**
+   * Returns a container holding {@code expression} and {@code codeSystemDefinitions}.
+   *
+   * @param expression            the expression being hold
+   * @param codeSystemDefinitions the code system definition being hold
+   * @param <T>                   the type of the expression
+   * @return a container
+   * @throws NullPointerException if {@code expression} is null
+   */
+  public static <T extends Expression> Container<T> of(T expression,
+      CodeSystemDefinition... codeSystemDefinitions) {
+    return new Container<>(requireNonNull(expression), Set.of(codeSystemDefinitions), Set.of());
+  }
+
+  /**
+   * Returns a container holding {@code expression} and {@code codeSystemDefinitions}.
+   *
+   * @param expression            the expression being hold
+   * @param codeSystemDefinitions the code system definition being hold
+   * @param referencedDefinitions the definitions that are referenced within the patient context
+   * @param <T>                   the type of the expression
+   * @return a container
+   * @throws NullPointerException if {@code expression} is null
+   */
+  public static <T extends Expression> Container<T> of(T expression,
+      Set<CodeSystemDefinition> codeSystemDefinitions,
+      Set<ExpressionDefinition> referencedDefinitions) {
+    return new Container<>(requireNonNull(expression), Set.copyOf(codeSystemDefinitions),
+        Set.copyOf(referencedDefinitions));
+  }
+
+  /**
+   * Returns a binary operator that combines expressions using {@code combiner} and the code system
+   * definitions with set union.
+   * <p>
+   * Because the {@link #empty() empty conatainer} is the identity element of the returned operator
+   * {@code op}, the following holds: {@code op.apply(empty, x) == x} and {@code op.apply(x, empty)
+   * == x}.
+   *
+   * @param combiner the binary operator to combine the expressions of both containers
+   * @param <T>      the type of both expressions
+   * @return a container holding the combined expression and the union of the code system
+   * definitions of both containers
+   * @throws NullPointerException if {@code combiner} is null
+   */
+  public static <T extends Expression> BinaryOperator<Container<T>> combiner(
+      BinaryOperator<T> combiner) {
+    return (a, b) -> a == EMPTY
+        ? b : b == EMPTY ? a : new Container<>(combiner.apply(a.expression, b.expression),
+        Sets.union(a.codeSystemDefinitions, b.codeSystemDefinitions),
+        Sets.union(a.referencedDefinitions, b.referencedDefinitions));
+  }
+
+  /**
+   * Returns the expression the container holds.
+   *
+   * @return the expression or {@link Optional#empty()} iff this container is {@link #isEmpty()
+   * empty}.
+   */
+  public Optional<T> getExpression() {
+    return Optional.ofNullable(expression);
+  }
+
+  /**
+   * Returns the code system definitions the container holds.
+   *
+   * @return the code system definitions the container holds
+   */
+  public Set<CodeSystemDefinition> getCodeSystemDefinitions() {
+    return codeSystemDefinitions;
+  }
+
+  /**
+   * Returns the definitions that are referenced within the patient context
+   *
+   * @return the expression definitions the container holds
+   */
+  public Set<ExpressionDefinition> getReferencedDefinitions() {
+    return referencedDefinitions;
+  }
+
+
+  /**
+   * Returns a container with the additional referenceDefinition
+   *
+   * @param name      used for the reference definition
+   * @param container container holding the reference definition including its
+   *                  codeSystemDefinitions
+   * @return a container with the additional reference definition and all additional
+   * codeSystemDefinitions and referencedDefinitions defined by it
+   */
+  public Container<T> addReferenceDefinition(String name, Container<?> container) {
+    if (isEmpty()) {
+      return empty();
     }
-
-    /**
-     * Returns the empty container that contains no expression and no code system definitions.
-     * <p>
-     * The empty container is the identity element of the binary {@link #combiner combine} operation.
-     *
-     * @param <T> the type of the expression
-     * @return the empty container
-     */
-    public static <T> Container<T> empty() {
-        @SuppressWarnings("unchecked")
-        Container<T> empty = (Container<T>) EMPTY;
-        return empty;
+    if (container.isEmpty()) {
+      return this;
     }
+    var exprDef = ExpressionDefinition.of(name, container.expression);
+    return Container.of(this.expression,
+        Sets.union(container.getCodeSystemDefinitions(), this.codeSystemDefinitions),
+        Sets.union(container.getReferencedDefinitions(),
+            Sets.union(this.referencedDefinitions, Set.of(exprDef))));
+  }
 
-    /**
-     * Returns a container holding {@code expression} and {@code codeSystemDefinitions}.
-     *
-     * @param expression            the expression being hold
-     * @param codeSystemDefinitions the code system definition being hold
-     * @param <T>                   the type of the expression
-     * @return a container
-     * @throws NullPointerException if {@code expression} is null
-     */
-    public static <T> Container<T> of(T expression, CodeSystemDefinition... codeSystemDefinitions) {
-        return new Container<>(requireNonNull(expression), Set.of(codeSystemDefinitions), Set.of());
-    }
 
-    /**
-     * Returns a container holding {@code expression} and {@code codeSystemDefinitions}.
-     *
-     * @param expression            the expression being hold
-     * @param codeSystemDefinitions the code system definition being hold
-     * @param <T>                   the type of the expression
-     * @param referencedDefinitions the definitions that are referenced within the patient context
-     * @return a container
-     * @throws NullPointerException if {@code expression} is null
-     */
-    public static <T> Container<T> of(T expression, Set<CodeSystemDefinition> codeSystemDefinitions, Set<ExpressionDefinition> referencedDefinitions) {
-        return new Container<>(requireNonNull(expression), codeSystemDefinitions, referencedDefinitions);
-    }
+  /**
+   * Returns {@code true} iff this container is empty.
+   *
+   * @return {@code true} iff this container is empty
+   */
+  public boolean isEmpty() {
+    return expression == null;
+  }
 
-    /**
-     * Returns a binary operator that combines expressions using {@code combiner} and the code system definitions with
-     * set union.
-     * <p>
-     * Because the {@link #empty() empty conatainer} is the identity element of the returned operator {@code op}, the
-     * following holds: {@code op.apply(empty, x) == x} and {@code op.apply(x, empty) == x}.
-     *
-     * @param combiner the binary operator to combine the expressions of both containers
-     * @param <T>      the type of both expressions
-     * @return a container holding the combined expression and the union of the code system definitions of both
-     * containers
-     * @throws NullPointerException if {@code combiner} is null
-     */
-    public static <T> BinaryOperator<Container<T>> combiner(BinaryOperator<T> combiner) {
-        return (a, b) -> a == EMPTY
-                ? b : b == EMPTY ? a : new Container<>(combiner.apply(a.expression, b.expression),
-                Sets.union(a.codeSystemDefinitions, b.codeSystemDefinitions), Sets.union(a.referencedDefinitions, b.referencedDefinitions));
-    }
+  public <U extends Expression> Container<U> map(Function<? super T, ? extends U> mapper) {
+    return isEmpty() ? empty() : new Container<>(requireNonNull(mapper.apply(expression)),
+        codeSystemDefinitions, referencedDefinitions);
+  }
 
-    /**
-     * Returns the expression the container holds.
-     *
-     * @return the expression or {@link Optional#empty()} iff this container is {@link #isEmpty() empty}.
-     */
-    public Optional<T> getExpression() {
-        return Optional.ofNullable(expression);
+  public <U extends Expression> Container<U> flatMap(
+      Function<? super T, ? extends Container<? extends U>> mapper) {
+    if (isEmpty()) {
+      return empty();
     }
-
-    /**
-     * Returns the code system definitions the container holds.
-     *
-     * @return the code system definitions the container holds
-     */
-    public Set<CodeSystemDefinition> getCodeSystemDefinitions() {
-        return codeSystemDefinitions;
+    Container<? extends U> container = mapper.apply(expression);
+    if (container.isEmpty()) {
+      return empty();
     }
-
-    /**
-     * Returns the referenced Codes
-     */
-    public Set<ExpressionDefinition> getReferencedDefinitions() {
-        return referencedDefinitions;
-    }
-
-    /**
-     * Returns {@code true} iff this container is empty.
-     *
-     * @return {@code true} iff this container is empty
-     */
-    public boolean isEmpty() {
-        return expression == null;
-    }
-
-    public <U> Container<U> map(Function<? super T, ? extends U> mapper) {
-        return isEmpty() ? empty() : new Container<>(requireNonNull(mapper.apply(expression)),
-                codeSystemDefinitions, referencedDefinitions);
-    }
-
-    public <U> Container<U> flatMap(Function<? super T, ? extends Container<? extends U>> mapper) {
-        if (isEmpty()) {
-            return empty();
-        }
-        Container<? extends U> container = mapper.apply(expression);
-        if (container.isEmpty()) {
-            return empty();
-        }
-        assert container.getExpression().isPresent();
-        return new Container<>(requireNonNull(container.getExpression().get()),
-                Sets.union(codeSystemDefinitions, container.getCodeSystemDefinitions()),
-                Sets.union(referencedDefinitions, container.getReferencedDefinitions()));
-    }
+    assert container.getExpression().isPresent();
+    return new Container<>(requireNonNull(container.getExpression().get()),
+        Sets.union(codeSystemDefinitions, container.getCodeSystemDefinitions()),
+        Sets.union(referencedDefinitions, container.getReferencedDefinitions()));
+  }
 }

--- a/src/main/java/de/numcodex/sq2cql/Container.java
+++ b/src/main/java/de/numcodex/sq2cql/Container.java
@@ -80,7 +80,7 @@ public final class Container<T extends Expression> {
    * @return a container
    * @throws NullPointerException if {@code expression} is null
    */
-  public static <T extends Expression> Container<T> of(T expression,
+  private static <T extends Expression> Container<T> of(T expression,
       Set<CodeSystemDefinition> codeSystemDefinitions,
       Set<ExpressionDefinition> referencedDefinitions) {
     return new Container<>(requireNonNull(expression), Set.copyOf(codeSystemDefinitions),

--- a/src/main/java/de/numcodex/sq2cql/Translator.java
+++ b/src/main/java/de/numcodex/sq2cql/Translator.java
@@ -4,6 +4,7 @@ import de.numcodex.sq2cql.model.MappingContext;
 import de.numcodex.sq2cql.model.cql.AndExpression;
 import de.numcodex.sq2cql.model.cql.BooleanExpression;
 import de.numcodex.sq2cql.model.cql.CodeSystemDefinition;
+import de.numcodex.sq2cql.model.cql.Context;
 import de.numcodex.sq2cql.model.cql.ExpressionDefinition;
 import de.numcodex.sq2cql.model.cql.IdentifierExpression;
 import de.numcodex.sq2cql.model.cql.Library;
@@ -13,11 +14,13 @@ import de.numcodex.sq2cql.model.structured_query.StructuredQuery;
 import de.numcodex.sq2cql.model.structured_query.TranslationException;
 
 import java.util.List;
+import java.util.stream.Stream;
 
 /**
  * The translator from Structured Query to CQL.
  * <p>
- * It needs {@code mappings} and will produce a CQL {@link Library} by calling {@link #toCql(StructuredQuery) toCql}.
+ * It needs {@code mappings} and will produce a CQL {@link Library} by calling {@link
+ * #toCql(StructuredQuery) toCql}.
  * <p>
  * Instances are immutable and thread-safe.
  *
@@ -25,99 +28,119 @@ import java.util.List;
  */
 public class Translator {
 
-    public static final ExpressionDefinition IN_INITIAL_POPULATION = ExpressionDefinition
-            .of("InInitialPopulation", AndExpression.of(IdentifierExpression.of("Inclusion"), NotExpression
-                    .of(IdentifierExpression.of("Exclusion"))));
+  public static final ExpressionDefinition IN_INITIAL_POPULATION = ExpressionDefinition
+      .of("InInitialPopulation",
+          AndExpression.of(IdentifierExpression.of("Inclusion"), NotExpression
+              .of(IdentifierExpression.of("Exclusion"))));
 
-    private final MappingContext mappingContext;
+  private final MappingContext mappingContext;
 
-    private Translator(MappingContext mappingContext) {
-        this.mappingContext = mappingContext;
+  private Translator(MappingContext mappingContext) {
+    this.mappingContext = mappingContext;
+  }
+
+  /**
+   * Returns a translator without any mappings.
+   *
+   * @return a translator without any mappings
+   */
+  public static Translator of() {
+    return new Translator(MappingContext.of());
+  }
+
+  /**
+   * Returns a translator with mappings defined in {@code mappingContext}.
+   *
+   * @return a translator with mappings defined in {@code mappingContext}
+   */
+  public static Translator of(MappingContext mappingContext) {
+    return new Translator(mappingContext);
+  }
+
+  private static Library inclusionOnlyLibrary(Container<BooleanExpression> inclusionExpr) {
+    assert inclusionExpr.getExpression().isPresent();
+    var UndefinedContext = Context.of("Unfiltered",
+        List.copyOf(inclusionExpr.getReferencedDefinitions()));
+    var PatientContext = Context.of("Patient", List.of(
+        ExpressionDefinition.of("InInitialPopulation", inclusionExpr.getExpression().get())));
+    if (UndefinedContext.expressionDefinitions().isEmpty()) {
+      return Library.of(inclusionExpr.getCodeSystemDefinitions(), List.of(PatientContext));
+    }
+    return Library.of(inclusionExpr.getCodeSystemDefinitions(),
+        List.of(UndefinedContext, PatientContext));
+  }
+
+  private static Library library(Container<BooleanExpression> inclusionExpr,
+      Container<BooleanExpression> exclusionExpr) {
+    assert inclusionExpr.getExpression().isPresent();
+    assert exclusionExpr.getExpression().isPresent();
+    var definitions = Stream.concat(exclusionExpr.getReferencedDefinitions().stream(),
+        inclusionExpr.getReferencedDefinitions().stream()).toList();
+    var UndefinedContext = Context.of("Unfiltered", definitions);
+    var PatientContext = Context.of("Patient",
+        List.of(ExpressionDefinition.of("Inclusion", inclusionExpr.getExpression().get()),
+            ExpressionDefinition.of("Exclusion", exclusionExpr.getExpression().get()),
+            IN_INITIAL_POPULATION));
+
+    if (UndefinedContext.expressionDefinitions().isEmpty()) {
+      return Library.of(Sets.union(inclusionExpr.getCodeSystemDefinitions(),
+          exclusionExpr.getCodeSystemDefinitions()), List.of(PatientContext));
+    }
+    return Library.of(Sets.union(inclusionExpr.getCodeSystemDefinitions(),
+        exclusionExpr.getCodeSystemDefinitions()), List.of(UndefinedContext, PatientContext)
+    );
+  }
+
+  /**
+   * Translates the given {@code structuredQuery} into a CQL {@link Library}.
+   *
+   * @param structuredQuery the Structured Query to translate
+   * @return the translated CQL {@link Library}
+   * @throws TranslationException if the given {@code structuredQuery} can't be translated into a
+   *                              CQL {@link Library}
+   */
+  public Library toCql(StructuredQuery structuredQuery) {
+    Container<BooleanExpression> inclusionExpr = inclusionExpr(structuredQuery.inclusionCriteria());
+    Container<BooleanExpression> exclusionExpr = exclusionExpr(structuredQuery.exclusionCriteria());
+
+    if (inclusionExpr.isEmpty()) {
+      throw new IllegalStateException("Inclusion criteria lead to empty inclusion expression.");
     }
 
-    /**
-     * Returns a translator without any mappings.
-     *
-     * @return a translator without any mappings
-     */
-    public static Translator of() {
-        return new Translator(MappingContext.of());
-    }
+    return exclusionExpr.isEmpty()
+        ? inclusionOnlyLibrary(inclusionExpr)
+        : library(inclusionExpr, exclusionExpr);
+  }
 
-    /**
-     * Returns a translator with mappings defined in {@code mappingContext}.
-     *
-     * @return a translator with mappings defined in {@code mappingContext}
-     */
-    public static Translator of(MappingContext mappingContext) {
-        return new Translator(mappingContext);
-    }
+  /**
+   * Builds the inclusion expression as conjunctive normal form (CNF) of {@code criteria}.
+   *
+   * @param criteria a list of lists of {@link Criterion} representing a CNF
+   * @return a {@link Container} of the boolean inclusion expression together with the used {@link
+   * CodeSystemDefinition CodeSystemDefinitions}
+   */
+  private Container<BooleanExpression> inclusionExpr(List<List<Criterion>> criteria) {
+    return criteria.stream().map(this::orExpr).reduce(Container.empty(), Container.AND);
+  }
 
-    private static Library inclusionOnlyLibrary(Container<BooleanExpression> inclusionExpr) {
-        assert inclusionExpr.getExpression().isPresent();
+  private Container<BooleanExpression> orExpr(List<Criterion> criteria) {
+    return criteria.stream().map(c -> c.toCql(mappingContext))
+        .reduce(Container.empty(), Container.OR);
+  }
 
-        return Library.of(inclusionExpr.getCodeSystemDefinitions(),
-                List.of(ExpressionDefinition.of("InInitialPopulation", inclusionExpr.getExpression().get())));
-    }
+  /**
+   * Builds the exclusion expression as disjunctive normal form (DNF) of {@code criteria}.
+   *
+   * @param criteria a list of lists of {@link Criterion} representing a DNF
+   * @return a {@link Container} of the boolean exclusion expression together with the used {@link
+   * CodeSystemDefinition CodeSystemDefinitions}
+   */
+  private Container<BooleanExpression> exclusionExpr(List<List<Criterion>> criteria) {
+    return criteria.stream().map(this::andExpr).reduce(Container.empty(), Container.OR);
+  }
 
-    private static Library library(Container<BooleanExpression> inclusionExpr,
-                                   Container<BooleanExpression> exclusionExpr) {
-        assert inclusionExpr.getExpression().isPresent();
-        assert exclusionExpr.getExpression().isPresent();
-
-        return Library.of(Sets.union(inclusionExpr.getCodeSystemDefinitions(), exclusionExpr.getCodeSystemDefinitions()),
-                List.of(ExpressionDefinition.of("Inclusion", inclusionExpr.getExpression().get()),
-                        ExpressionDefinition.of("Exclusion", exclusionExpr.getExpression().get()),
-                        IN_INITIAL_POPULATION));
-    }
-
-    /**
-     * Translates the given {@code structuredQuery} into a CQL {@link Library}.
-     *
-     * @param structuredQuery the Structured Query to translate
-     * @return the translated CQL {@link Library}
-     * @throws TranslationException if the given {@code structuredQuery} can't be translated into a CQL {@link Library}
-     */
-    public Library toCql(StructuredQuery structuredQuery) {
-        Container<BooleanExpression> inclusionExpr = inclusionExpr(structuredQuery.inclusionCriteria());
-        Container<BooleanExpression> exclusionExpr = exclusionExpr(structuredQuery.exclusionCriteria());
-
-        if (inclusionExpr.isEmpty()) {
-            throw new IllegalStateException("Inclusion criteria lead to empty inclusion expression.");
-        }
-
-        return exclusionExpr.isEmpty()
-                ? inclusionOnlyLibrary(inclusionExpr)
-                : library(inclusionExpr, exclusionExpr);
-    }
-
-    /**
-     * Builds the inclusion expression as conjunctive normal form (CNF) of {@code criteria}.
-     *
-     * @param criteria a list of lists of {@link Criterion} representing a CNF
-     * @return a {@link Container} of the boolean inclusion expression together with the used
-     * {@link CodeSystemDefinition CodeSystemDefinitions}
-     */
-    private Container<BooleanExpression> inclusionExpr(List<List<Criterion>> criteria) {
-        return criteria.stream().map(this::orExpr).reduce(Container.empty(), Container.AND);
-    }
-
-    private Container<BooleanExpression> orExpr(List<Criterion> criteria) {
-        return criteria.stream().map(c -> c.toCql(mappingContext)).reduce(Container.empty(), Container.OR);
-    }
-
-    /**
-     * Builds the exclusion expression as disjunctive normal form (DNF) of {@code criteria}.
-     *
-     * @param criteria a list of lists of {@link Criterion} representing a DNF
-     * @return a {@link Container} of the boolean exclusion expression together with the used
-     * {@link CodeSystemDefinition CodeSystemDefinitions}
-     */
-    private Container<BooleanExpression> exclusionExpr(List<List<Criterion>> criteria) {
-        return criteria.stream().map(this::andExpr).reduce(Container.empty(), Container.OR);
-    }
-
-    private Container<BooleanExpression> andExpr(List<Criterion> criteria) {
-        return criteria.stream().map(c -> c.toCql(mappingContext)).reduce(Container.empty(), Container.AND);
-    }
+  private Container<BooleanExpression> andExpr(List<Criterion> criteria) {
+    return criteria.stream().map(c -> c.toCql(mappingContext))
+        .reduce(Container.empty(), Container.AND);
+  }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/AdditionExpressionTerm.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/AdditionExpressionTerm.java
@@ -10,11 +10,13 @@ import java.util.stream.Stream;
 public record AdditionExpressionTerm(List<ExpressionTerm> expressions) implements
     ExpressionTerm {
 
+  public static final int PRECEDENCE = 16;
+
+
   public AdditionExpressionTerm {
-    List.copyOf(expressions);
+    expressions = List.copyOf(expressions);
   }
 
-  public static final int PRECEDENCE = 16;
 
   public static Expression of(ExpressionTerm e1, ExpressionTerm e2) {
     if (e1 instanceof AdditionExpressionTerm) {

--- a/src/main/java/de/numcodex/sq2cql/model/cql/AdditionExpressionTerm.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/AdditionExpressionTerm.java
@@ -1,0 +1,36 @@
+package de.numcodex.sq2cql.model.cql;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+
+import de.numcodex.sq2cql.PrintContext;
+import java.util.List;
+import java.util.stream.Stream;
+
+public record AdditionExpressionTerm(List<ExpressionTerm> expressions) implements
+    ExpressionTerm {
+
+  public AdditionExpressionTerm {
+    List.copyOf(expressions);
+  }
+
+  public static final int PRECEDENCE = 16;
+
+  public static Expression of(ExpressionTerm e1, ExpressionTerm e2) {
+    if (e1 instanceof AdditionExpressionTerm) {
+      return new AdditionExpressionTerm(
+          Stream.concat(((AdditionExpressionTerm) e1).expressions.stream(),
+              Stream.of(requireNonNull(e2))).toList());
+    } else {
+      return new AdditionExpressionTerm(List.of(requireNonNull(e1), requireNonNull(e2)));
+    }
+  }
+
+
+  @Override
+  public String print(PrintContext printContext) {
+    return printContext.parenthesize(PRECEDENCE, expressions.stream()
+        .map(printContext.withPrecedence(PRECEDENCE)::print)
+        .collect(joining(" + ")));
+  }
+}

--- a/src/main/java/de/numcodex/sq2cql/model/cql/CodeSelector.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/CodeSelector.java
@@ -4,7 +4,7 @@ import de.numcodex.sq2cql.PrintContext;
 
 import static java.util.Objects.requireNonNull;
 
-public record CodeSelector(String code, String codeSystemIdentifier) implements TermExpression {
+public record CodeSelector(String code, String codeSystemIdentifier) implements ExpressionTerm {
 
     public CodeSelector {
         requireNonNull(code);

--- a/src/main/java/de/numcodex/sq2cql/model/cql/Context.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/Context.java
@@ -1,14 +1,16 @@
 package de.numcodex.sq2cql.model.cql;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 
 import de.numcodex.sq2cql.PrintContext;
 import java.util.List;
 
-public record Context(String contextName, List<ExpressionDefinition> expressionDefinitions) {
+public record Context(String name, List<ExpressionDefinition> expressionDefinitions) {
 
 
   public Context {
+    requireNonNull(name);
     expressionDefinitions = List.copyOf(expressionDefinitions);
   }
 
@@ -20,11 +22,11 @@ public record Context(String contextName, List<ExpressionDefinition> expressionD
     return new Context(contextName, expressionDefinitions);
   }
 
-  public String print(PrintContext printContext) {
+  public String print() {
     return """
         context %s
         
-        %s""".formatted(contextName, expressionDefinitions.stream().map(d -> d.print(printContext)).collect(joining("\n\n")));
+        %s""".formatted(name, expressionDefinitions.stream().map(d -> d.print(PrintContext.ZERO)).collect(joining("\n\n")));
   }
 
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/Context.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/Context.java
@@ -1,0 +1,30 @@
+package de.numcodex.sq2cql.model.cql;
+
+import static java.util.stream.Collectors.joining;
+
+import de.numcodex.sq2cql.PrintContext;
+import java.util.List;
+
+public record Context(String contextName, List<ExpressionDefinition> expressionDefinitions) {
+
+
+  public Context {
+    expressionDefinitions = List.copyOf(expressionDefinitions);
+  }
+
+  public static Context of() {
+    return new Context("", List.of());
+  }
+
+  public static Context of(String contextName, List<ExpressionDefinition> expressionDefinitions) {
+    return new Context(contextName, expressionDefinitions);
+  }
+
+  public String print(PrintContext printContext) {
+    return """
+        context %s
+        
+        %s""".formatted(contextName, expressionDefinitions.stream().map(d -> d.print(printContext)).collect(joining("\n\n")));
+  }
+
+}

--- a/src/main/java/de/numcodex/sq2cql/model/cql/ExpressionTerm.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/ExpressionTerm.java
@@ -1,0 +1,4 @@
+package de.numcodex.sq2cql.model.cql;
+
+public interface ExpressionTerm extends Expression {
+}

--- a/src/main/java/de/numcodex/sq2cql/model/cql/IdentifierExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/IdentifierExpression.java
@@ -6,16 +6,17 @@ import static java.util.Objects.requireNonNull;
 
 public record IdentifierExpression(String identifier) implements BooleanExpression {
 
-    public IdentifierExpression {
-        requireNonNull(identifier);
-    }
+  public IdentifierExpression {
+    requireNonNull(identifier);
+  }
 
-    public static IdentifierExpression of(String identifier) {
-        return new IdentifierExpression(identifier);
-    }
+  public static IdentifierExpression of(String identifier) {
+    return new IdentifierExpression(identifier);
+  }
 
-    @Override
-    public String print(PrintContext printContext) {
-        return identifier;
-    }
+  @Override
+  public String print(PrintContext printContext) {
+    return identifier.matches("([A-Za-z]|'_')([A-Za-z0-9]|'_')*") ? identifier
+        : "\"%s\"".formatted(identifier);
+  }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/IdentifierExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/IdentifierExpression.java
@@ -16,7 +16,7 @@ public record IdentifierExpression(String identifier) implements BooleanExpressi
 
   @Override
   public String print(PrintContext printContext) {
-    return identifier.matches("([A-Za-z]|'_')([A-Za-z0-9]|'_')*") ? identifier
+    return identifier.matches("([A-Za-z]|_)([A-Za-z0-9]|_)*") ? identifier
         : "\"%s\"".formatted(identifier);
   }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/IntervalSelector.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/IntervalSelector.java
@@ -4,7 +4,7 @@ import de.numcodex.sq2cql.PrintContext;
 
 import static java.util.Objects.requireNonNull;
 
-public record IntervalSelector(Expression intervalStart, Expression intervalEnd) implements TermExpression {
+public record IntervalSelector(Expression intervalStart, Expression intervalEnd) implements ExpressionTerm {
 
   public IntervalSelector {
     requireNonNull(intervalStart);

--- a/src/main/java/de/numcodex/sq2cql/model/cql/InvocationExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/InvocationExpression.java
@@ -7,7 +7,7 @@ import static java.util.Objects.requireNonNull;
 /**
  * @author Alexander Kiel
  */
-public record InvocationExpression(Expression expression, String invocation) implements Expression {
+public record InvocationExpression(Expression expression, String invocation) implements ExpressionTerm {
 
     public InvocationExpression {
         requireNonNull(expression);

--- a/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
@@ -12,11 +12,11 @@ import static java.util.stream.Collectors.joining;
  * @author Alexander Kiel
  */
 public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
-                      List<ExpressionDefinition> expressionDefinitions) {
+                      List<Context> contexts) {
 
     public Library {
         codeSystemDefinitions = Set.copyOf(codeSystemDefinitions);
-        expressionDefinitions = List.copyOf(expressionDefinitions);
+        contexts = List.copyOf(contexts);
     }
 
     public static Library of() {
@@ -24,8 +24,8 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
     }
 
     public static Library of(Set<CodeSystemDefinition> codeSystemDefinitions,
-                             List<ExpressionDefinition> expressionDefinitions) {
-        return new Library(codeSystemDefinitions, expressionDefinitions);
+                             List<Context> contexts) {
+        return new Library(codeSystemDefinitions, contexts);
     }
 
     public String print(PrintContext printContext) {
@@ -34,12 +34,10 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
                 library Retrieve
                 using FHIR version '4.0.0'
                 include FHIRHelpers version '4.0.0'
-                      
-                context Patient
-                                
+                                      
                 %s
                 """
-                .formatted(expressionDefinitions.stream().map(d -> d.print(printContext)).collect(joining("\n\n")))
+                .formatted(contexts.stream().map(d -> d.print(printContext)).collect(joining("\n\n")))
                 : """
                 library Retrieve
                 using FHIR version '4.0.0'
@@ -47,13 +45,11 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
                                 
                 %s
                                 
-                context Patient
-                                
                 %s
                 """
                 .formatted(codeSystemDefinitions.stream()
                                 .sorted(Comparator.comparing(CodeSystemDefinition::name))
                                 .map(CodeSystemDefinition::print).collect(joining("\n")),
-                        expressionDefinitions.stream().map(d -> d.print(printContext)).collect(joining("\n\n")));
+                        contexts.stream().map(d -> d.print(printContext)).collect(joining("\n\n")));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
@@ -28,7 +28,7 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
         return new Library(codeSystemDefinitions, contexts);
     }
 
-    public String print(PrintContext printContext) {
+    public String print() {
         return codeSystemDefinitions.isEmpty()
                 ? """
                 library Retrieve
@@ -37,7 +37,7 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
                                       
                 %s
                 """
-                .formatted(contexts.stream().map(d -> d.print(printContext)).collect(joining("\n\n")))
+                .formatted(contexts.stream().map(Context::print).collect(joining("\n\n")))
                 : """
                 library Retrieve
                 using FHIR version '4.0.0'
@@ -50,6 +50,6 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
                 .formatted(codeSystemDefinitions.stream()
                                 .sorted(Comparator.comparing(CodeSystemDefinition::name))
                                 .map(CodeSystemDefinition::print).collect(joining("\n")),
-                        contexts.stream().map(d -> d.print(printContext)).collect(joining("\n\n")));
+                        contexts.stream().map(Context::print).collect(joining("\n\n")));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/ListSelector.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/ListSelector.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import static java.util.stream.Collectors.joining;
 
-public record ListSelector(List<? extends Expression> items) implements TermExpression {
+public record ListSelector(List<? extends Expression> items) implements ExpressionTerm {
 
     public ListSelector {
         items = List.copyOf(items);

--- a/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
@@ -1,7 +1,6 @@
 package de.numcodex.sq2cql.model.cql;
 
 import de.numcodex.sq2cql.PrintContext;
-import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -22,13 +21,13 @@ public record QueryExpression(SourceClause sourceClause, WhereClause whereClause
     @Override
     public String print(PrintContext printContext) {
         var sourcePrintContext = printContext.resetPrecedence();
-        if (!Objects.isNull(whereClause)) {
+        if (whereClause != null) {
             var wherePrintContext = sourcePrintContext.increase();
             return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.print(sourcePrintContext),
                 wherePrintContext.getIndent(),
                 whereClause.print(wherePrintContext)));
         }
-        else if (!Objects.isNull(returnClause)) {
+        else if (returnClause != null) {
             var returnPrintContext = sourcePrintContext.increase();
             return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.print(sourcePrintContext),
                 returnPrintContext.getIndent(),

--- a/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
@@ -24,15 +24,15 @@ public record QueryExpression(SourceClause sourceClause, WhereClause whereClause
         var sourcePrintContext = printContext.resetPrecedence();
         if (!Objects.isNull(whereClause)) {
             var wherePrintContext = sourcePrintContext.increase();
-            return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.toCql(sourcePrintContext),
+            return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.print(sourcePrintContext),
                 wherePrintContext.getIndent(),
-                whereClause.toCql(wherePrintContext)));
+                whereClause.print(wherePrintContext)));
         }
         else if (!Objects.isNull(returnClause)) {
             var returnPrintContext = sourcePrintContext.increase();
-            return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.toCql(sourcePrintContext),
+            return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.print(sourcePrintContext),
                 returnPrintContext.getIndent(),
-                returnClause.toCql(returnPrintContext)));
+                returnClause.print(returnPrintContext)));
         }
         else return "";
     }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/QueryExpression.java
@@ -1,25 +1,39 @@
 package de.numcodex.sq2cql.model.cql;
 
 import de.numcodex.sq2cql.PrintContext;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public record QueryExpression(SourceClause sourceClause, WhereClause whereClause) implements Expression {
+public record QueryExpression(SourceClause sourceClause, WhereClause whereClause, ReturnClause returnClause) implements Expression {
 
     public QueryExpression {
         requireNonNull(sourceClause);
-        requireNonNull(whereClause);
     }
 
     public static QueryExpression of(SourceClause sourceClause, WhereClause whereClause) {
-        return new QueryExpression(sourceClause, whereClause);
+        return new QueryExpression(sourceClause, whereClause, null);
+    }
+
+    public static QueryExpression of(SourceClause sourceClause, ReturnClause returnClause) {
+        return new QueryExpression(sourceClause, null, returnClause);
     }
 
     @Override
     public String print(PrintContext printContext) {
         var sourcePrintContext = printContext.resetPrecedence();
-        var wherePrintContext = sourcePrintContext.increase();
-        return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.toCql(sourcePrintContext),
-                wherePrintContext.getIndent(), whereClause.toCql(wherePrintContext)));
+        if (!Objects.isNull(whereClause)) {
+            var wherePrintContext = sourcePrintContext.increase();
+            return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.toCql(sourcePrintContext),
+                wherePrintContext.getIndent(),
+                whereClause.toCql(wherePrintContext)));
+        }
+        else if (!Objects.isNull(returnClause)) {
+            var returnPrintContext = sourcePrintContext.increase();
+            return printContext.parenthesizeZero("%s\n%s%s".formatted(sourceClause.toCql(sourcePrintContext),
+                returnPrintContext.getIndent(),
+                returnClause.toCql(returnPrintContext)));
+        }
+        else return "";
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
@@ -1,6 +1,7 @@
 package de.numcodex.sq2cql.model.cql;
 
 import de.numcodex.sq2cql.PrintContext;
+import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
@@ -8,7 +9,10 @@ public record RetrieveExpression(String resourceType, Expression terminology) im
 
     public RetrieveExpression {
         requireNonNull(resourceType);
-        requireNonNull(terminology);
+    }
+
+    public static RetrieveExpression of(String resourceType) {
+        return new RetrieveExpression(resourceType, null);
     }
 
     public static RetrieveExpression of(String resourceType, Expression terminology) {
@@ -17,6 +21,9 @@ public record RetrieveExpression(String resourceType, Expression terminology) im
 
     @Override
     public String print(PrintContext printContext) {
+        if(Objects.isNull(terminology)) {
+            return "[%s]".formatted(resourceType);
+        }
         return "[%s: %s]".formatted(resourceType, terminology.print(printContext.resetPrecedence()));
     }
 

--- a/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/RetrieveExpression.java
@@ -5,29 +5,28 @@ import java.util.Objects;
 
 import static java.util.Objects.requireNonNull;
 
-public record RetrieveExpression(String resourceType, Expression terminology) implements Expression {
+public record RetrieveExpression(String resourceType, Expression terminology) implements
+    Expression {
 
-    public RetrieveExpression {
-        requireNonNull(resourceType);
-    }
+  public RetrieveExpression {
+    requireNonNull(resourceType);
+  }
 
-    public static RetrieveExpression of(String resourceType) {
-        return new RetrieveExpression(resourceType, null);
-    }
+  public static RetrieveExpression of(String resourceType) {
+    return new RetrieveExpression(resourceType, null);
+  }
 
-    public static RetrieveExpression of(String resourceType, Expression terminology) {
-        return new RetrieveExpression(resourceType, terminology);
-    }
+  public static RetrieveExpression of(String resourceType, Expression terminology) {
+    return new RetrieveExpression(resourceType, terminology);
+  }
 
-    @Override
-    public String print(PrintContext printContext) {
-        if(Objects.isNull(terminology)) {
-            return "[%s]".formatted(resourceType);
-        }
-        return "[%s: %s]".formatted(resourceType, terminology.print(printContext.resetPrecedence()));
-    }
+  @Override
+  public String print(PrintContext printContext) {
+    return terminology == null ? "[%s]".formatted(resourceType)
+        : "[%s: %s]".formatted(resourceType, terminology.print(printContext.resetPrecedence()));
+  }
 
-    public IdentifierExpression alias() {
-        return IdentifierExpression.of(resourceType.substring(0, 1));
-    }
+  public IdentifierExpression alias() {
+    return IdentifierExpression.of(resourceType.substring(0, 1));
+  }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/ReturnClause.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/ReturnClause.java
@@ -1,0 +1,20 @@
+package de.numcodex.sq2cql.model.cql;
+
+import static java.util.Objects.requireNonNull;
+
+import de.numcodex.sq2cql.PrintContext;
+
+public record ReturnClause(Expression expression) {
+
+  public ReturnClause {
+    requireNonNull(expression);
+  }
+
+  public static ReturnClause of(Expression expression) {
+    return new ReturnClause(expression);
+  }
+
+  public String toCql(PrintContext printContext) {
+    return "return " + expression.print(printContext.resetPrecedence().increase());
+  }
+}

--- a/src/main/java/de/numcodex/sq2cql/model/cql/ReturnClause.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/ReturnClause.java
@@ -14,7 +14,7 @@ public record ReturnClause(Expression expression) {
     return new ReturnClause(expression);
   }
 
-  public String toCql(PrintContext printContext) {
+  public String print(PrintContext printContext) {
     return "return " + expression.print(printContext.resetPrecedence().increase());
   }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/SourceClause.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/SourceClause.java
@@ -4,7 +4,7 @@ import de.numcodex.sq2cql.PrintContext;
 
 import static java.util.Objects.requireNonNull;
 
-public record SourceClause(Expression querySource, IdentifierExpression alias, boolean from) {
+public record SourceClause(Expression querySource, IdentifierExpression alias) {
 
     public SourceClause {
         requireNonNull(querySource);
@@ -12,15 +12,11 @@ public record SourceClause(Expression querySource, IdentifierExpression alias, b
     }
 
     public static SourceClause of(Expression querySource, IdentifierExpression alias) {
-        return new SourceClause(querySource, alias, false);
+        return new SourceClause(querySource, alias);
     }
 
-    public static SourceClause from(Expression querySource, IdentifierExpression alias) {
-        return new SourceClause(querySource, alias, true);
-    }
-
-    public String toCql(PrintContext printContext) {
+    public String print(PrintContext printContext) {
         assert printContext.precedence() == 0;
-        return "%s%s %s".formatted(from ? "from " : "", querySource.print(printContext.increase()), alias.print(printContext));
+        return "from %s %s".formatted(querySource.print(printContext.increase()), alias.print(printContext));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/SourceClause.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/SourceClause.java
@@ -4,7 +4,7 @@ import de.numcodex.sq2cql.PrintContext;
 
 import static java.util.Objects.requireNonNull;
 
-public record SourceClause(Expression querySource, IdentifierExpression alias) {
+public record SourceClause(Expression querySource, IdentifierExpression alias, boolean from) {
 
     public SourceClause {
         requireNonNull(querySource);
@@ -12,11 +12,15 @@ public record SourceClause(Expression querySource, IdentifierExpression alias) {
     }
 
     public static SourceClause of(Expression querySource, IdentifierExpression alias) {
-        return new SourceClause(querySource, alias);
+        return new SourceClause(querySource, alias, false);
+    }
+
+    public static SourceClause from(Expression querySource, IdentifierExpression alias) {
+        return new SourceClause(querySource, alias, true);
     }
 
     public String toCql(PrintContext printContext) {
         assert printContext.precedence() == 0;
-        return "from %s %s".formatted(querySource.print(printContext), alias.print(printContext));
+        return "%s%s %s".formatted(from ? "from " : "", querySource.print(printContext.increase()), alias.print(printContext));
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/cql/StringLiteralExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/StringLiteralExpression.java
@@ -4,7 +4,8 @@ import de.numcodex.sq2cql.PrintContext;
 
 import static java.util.Objects.requireNonNull;
 
-public record StringLiteralExpression(String value) implements Expression {
+
+public record StringLiteralExpression(String value) implements ExpressionTerm {
 
     public StringLiteralExpression {
         requireNonNull(value);

--- a/src/main/java/de/numcodex/sq2cql/model/cql/TermExpression.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/TermExpression.java
@@ -1,4 +1,0 @@
-package de.numcodex.sq2cql.model.cql;
-
-public interface TermExpression extends Expression {
-}

--- a/src/main/java/de/numcodex/sq2cql/model/cql/WhereClause.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/WhereClause.java
@@ -14,7 +14,7 @@ public record WhereClause(Expression expression) {
         return new WhereClause(expression);
     }
 
-    public String toCql(PrintContext printContext) {
+    public String print(PrintContext printContext) {
         assert printContext.precedence() == 0;
         return "where " + expression.print(printContext.increase());
     }

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/AbstractCriterion.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/AbstractCriterion.java
@@ -14,6 +14,7 @@ import de.numcodex.sq2cql.model.cql.IdentifierExpression;
 import de.numcodex.sq2cql.model.cql.QueryExpression;
 import de.numcodex.sq2cql.model.cql.RetrieveExpression;
 import de.numcodex.sq2cql.model.cql.SourceClause;
+import de.numcodex.sq2cql.model.cql.StringLiteralExpression;
 import de.numcodex.sq2cql.model.cql.WhereClause;
 
 import java.util.List;
@@ -28,133 +29,174 @@ import static java.util.Objects.requireNonNull;
  */
 abstract class AbstractCriterion implements Criterion {
 
-    private static final IdentifierExpression PATIENT = IdentifierExpression.of("Patient");
+  private static final IdentifierExpression PATIENT = IdentifierExpression.of("Patient");
 
-    final Concept concept;
-    final List<AttributeFilter> attributeFilters;
-    final TimeRestriction timeRestriction;
+  final Concept concept;
+  final List<AttributeFilter> attributeFilters;
+  final TimeRestriction timeRestriction;
 
-    AbstractCriterion(Concept concept, List<AttributeFilter> attributeFilters, TimeRestriction timeRestriction) {
-        this.concept = requireNonNull(concept);
-        this.attributeFilters = List.copyOf(attributeFilters);
-        this.timeRestriction = timeRestriction;
+  AbstractCriterion(Concept concept, List<AttributeFilter> attributeFilters,
+      TimeRestriction timeRestriction) {
+    this.concept = requireNonNull(concept);
+    this.attributeFilters = List.copyOf(attributeFilters);
+    this.timeRestriction = timeRestriction;
+  }
+
+  /**
+   * Returns the code selector expression according to the given term code.
+   *
+   * @param mappingContext the mapping context to determine the code system definition of the
+   *                       concept
+   * @param termCode       the term code to use
+   * @return a {@link Container} of the code selector expression together with its used {@link
+   * CodeSystemDefinition}
+   */
+  static Container<CodeSelector> codeSelector(MappingContext mappingContext, TermCode termCode) {
+    var codeSystemDefinition = mappingContext.findCodeSystemDefinition(termCode.system())
+        .orElseThrow(() -> new IllegalStateException("code system alias for `%s` not found"
+            .formatted(termCode.system())));
+    return Container.of(CodeSelector.of(termCode.code(), codeSystemDefinition.name()),
+        codeSystemDefinition);
+  }
+
+  /**
+   * Returns the name of a coding as stringliteralExpression to use as reference
+   */
+  static IdentifierExpression referenceName(MappingContext mappingContext,
+      TermCode termCode) {
+    return IdentifierExpression.of("\"%s\"".formatted(termCode.display()));
+  }
+
+
+  /**
+   * Returns the retrieve expression according to the given term code.
+   * <p>
+   * Uses the mapping context to determine the resource type of the retrieve expression and the code
+   * system definition of the concept.
+   *
+   * @param mappingContext the mapping context
+   * @param termCode       the term code to use
+   * @return a {@link Container} of the retrieve expression together with its used {@link
+   * CodeSystemDefinition}
+   * @throws TranslationException if the {@link RetrieveExpression} can't be build
+   */
+  static Container<RetrieveExpression> retrieveExpr(MappingContext mappingContext,
+      TermCode termCode) {
+    return codeSelector(mappingContext, termCode).map(terminology -> {
+      var mapping = mappingContext.findMapping(termCode)
+          .orElseThrow(() -> new MappingNotFoundException(termCode));
+      return RetrieveExpression.of(mapping.resourceType(), terminology);
+    });
+  }
+
+
+  static Container<RetrieveExpression> retrieveResourceTypeExpr(MappingContext mappingContext,
+      TermCode termCode) {
+    return codeSelector(mappingContext, termCode).map(terminology -> {
+      var mapping = mappingContext.findMapping(termCode)
+          .orElseThrow(() -> new MappingNotFoundException(termCode));
+      return RetrieveExpression.of(mapping.resourceType());
+    });
+  }
+
+
+  static Container<BooleanExpression> modifiersExpr(List<Modifier> modifiers,
+      MappingContext mappingContext,
+      IdentifierExpression identifier) {
+    return modifiers.stream()
+        .map(m -> m.expression(mappingContext, identifier))
+        .reduce(Container.empty(), Container.AND);
+  }
+
+  static ExistsExpression existsExpr(SourceClause sourceClause, BooleanExpression whereExpr) {
+    return ExistsExpression.of(QueryExpression.of(sourceClause, WhereClause.of(whereExpr)));
+  }
+
+  public Concept getConcept() {
+    return concept;
+  }
+
+  @Override
+  public Container<BooleanExpression> toCql(MappingContext mappingContext) {
+    var expr = fullExpr(mappingContext);
+    if (expr.isEmpty()) {
+      throw new TranslationException("Failed to expand the concept %s.".formatted(concept));
     }
+    return expr;
+  }
 
-    /**
-     * Returns the code selector expression according to the given term code.
-     *
-     * @param mappingContext the mapping context to determine the code system definition of the
-     *                       concept
-     * @param termCode       the term code to use
-     * @return a {@link Container} of the code selector expression together with its used {@link
-     * CodeSystemDefinition}
-     */
-    static Container<CodeSelector> codeSelector(MappingContext mappingContext, TermCode termCode) {
-        var codeSystemDefinition = mappingContext.findCodeSystemDefinition(termCode.system())
-                .orElseThrow(() -> new IllegalStateException("code system alias for `%s` not found"
-                        .formatted(termCode.system())));
-        return Container.of(CodeSelector.of(termCode.code(), codeSystemDefinition.name()), codeSystemDefinition);
-    }
+  /**
+   * Builds an OR-expression with an expression for each concept of the expansion of {@code
+   * termCode}.
+   */
+  private Container<BooleanExpression> fullExpr(MappingContext mappingContext) {
+    return mappingContext.expandConcept(concept)
+        .map(termCode -> expr(mappingContext, termCode))
+        .reduce(Container.empty(), Container.OR);
+  }
 
-    /**
-     * Returns the retrieve expression according to the given term code.
-     * <p>
-     * Uses the mapping context to determine the resource type of the retrieve expression and the code
-     * system definition of the concept.
-     *
-     * @param mappingContext the mapping context
-     * @param termCode       the term code to use
-     * @return a {@link Container} of the retrieve expression together with its used {@link
-     * CodeSystemDefinition}
-     * @throws TranslationException if the {@link RetrieveExpression} can't be build
-     */
-    static Container<RetrieveExpression> retrieveExpr(MappingContext mappingContext,
-                                                      TermCode termCode) {
-        return codeSelector(mappingContext, termCode).map(terminology -> {
-            var mapping = mappingContext.findMapping(termCode)
-                    .orElseThrow(() -> new MappingNotFoundException(termCode));
-            return RetrieveExpression.of(mapping.resourceType(), terminology);
-        });
-    }
-
-    static Container<BooleanExpression> modifiersExpr(List<Modifier> modifiers, MappingContext mappingContext,
-                                                      IdentifierExpression identifier) {
-        return modifiers.stream()
-                .map(m -> m.expression(mappingContext, identifier))
-                .reduce(Container.empty(), Container.AND);
-    }
-
-    static ExistsExpression existsExpr(SourceClause sourceClause, BooleanExpression whereExpr) {
-        return ExistsExpression.of(QueryExpression.of(sourceClause, WhereClause.of(whereExpr)));
-    }
-
-    public Concept getConcept() {
-        return concept;
-    }
-
-    @Override
-    public Container<BooleanExpression> toCql(MappingContext mappingContext) {
-        var expr = fullExpr(mappingContext);
-        if (expr.isEmpty()) {
-            throw new TranslationException("Failed to expand the concept %s.".formatted(concept));
-        }
-        return expr;
-    }
-
-    /**
-     * Builds an OR-expression with an expression for each concept of the expansion of {@code termCode}.
-     */
-    private Container<BooleanExpression> fullExpr(MappingContext mappingContext) {
-        return mappingContext.expandConcept(concept)
-                .map(termCode -> expr(mappingContext, termCode))
-                .reduce(Container.empty(), Container.OR);
-    }
-
-    private Container<BooleanExpression> expr(MappingContext mappingContext, TermCode termCode) {
-        var mapping = mappingContext.findMapping(termCode).orElseThrow(() -> new MappingNotFoundException(termCode));
-        if ("Patient".equals(mapping.resourceType())) {
-            return valueAndModifierExpr(mappingContext, mapping, PATIENT);
+  private Container<BooleanExpression> expr(MappingContext mappingContext, TermCode termCode) {
+    var mapping = mappingContext.findMapping(termCode)
+        .orElseThrow(() -> new MappingNotFoundException(termCode));
+    if ("Patient".equals(mapping.resourceType())) {
+      return valueAndModifierExpr(mappingContext, mapping, PATIENT);
+    } else if ("MedicationAdministration".equals(mapping.resourceType())) {
+      return retrieveResourceTypeExpr(mappingContext, termCode).flatMap(retrieveExpr -> {
+        var self = ReferenceCriterion.from(this, termCode);
+        var alias = retrieveExpr.alias();
+        var sourceClause = SourceClause.from(retrieveExpr, alias);
+        var valueAndModifierExpr = self.valueAndModifierExpr(mappingContext, mapping, alias);
+        if (valueAndModifierExpr.isEmpty()) {
+          return Container.of(ExistsExpression.of(retrieveExpr));
         } else {
-            return retrieveExpr(mappingContext, termCode).flatMap(retrieveExpr -> {
-                var alias = retrieveExpr.alias();
-                var sourceClause = SourceClause.of(retrieveExpr, alias);
-                var valueAndModifierExpr = valueAndModifierExpr(mappingContext, mapping, alias);
-                if (valueAndModifierExpr.isEmpty()) {
-                    return Container.of(ExistsExpression.of(retrieveExpr));
-                } else {
-                    return valueAndModifierExpr.map(expr -> existsExpr(sourceClause, expr));
-                }
-            });
+          return valueAndModifierExpr.map(expr -> existsExpr(sourceClause, expr));
         }
-    }
-
-    private Container<BooleanExpression> valueAndModifierExpr(MappingContext mappingContext, Mapping mapping,
-                                                              IdentifierExpression identifier) {
-        var valueExpr = valueExpr(mappingContext, mapping, identifier);
-        var modifiers = Lists.concat(mapping.fixedCriteria(), resolveAttributeModifiers(mapping.attributeMappings()));
-        if (Objects.nonNull(timeRestriction)) {
-            modifiers = Lists.concat(modifiers, List.of(timeRestriction.toModifier(mapping)));
-        }
-        if (modifiers.isEmpty()) {
-            return valueExpr;
+      });
+    } else {
+      return retrieveExpr(mappingContext, termCode).flatMap(retrieveExpr -> {
+        var alias = retrieveExpr.alias();
+        var sourceClause = SourceClause.from(retrieveExpr, alias);
+        var valueAndModifierExpr = valueAndModifierExpr(mappingContext, mapping, alias);
+        if (valueAndModifierExpr.isEmpty()) {
+          return Container.of(ExistsExpression.of(retrieveExpr));
         } else {
-            return Container.AND.apply(valueExpr, modifiersExpr(modifiers, mappingContext, identifier));
+          return valueAndModifierExpr.map(expr -> existsExpr(sourceClause, expr));
         }
+      });
     }
+  }
 
-    abstract Container<BooleanExpression> valueExpr(MappingContext mappingContext, Mapping mapping,
-                                                    IdentifierExpression identifier);
-
-    private List<Modifier> resolveAttributeModifiers(Map<TermCode, AttributeMapping> attributeMappings) {
-        return attributeFilters.stream().map(attributeFilter -> {
-            var key = attributeFilter.attributeCode();
-            var mapping = Optional.ofNullable(attributeMappings.get(key)).orElseThrow(() ->
-                    new MappingNotFoundException(key));
-            return attributeFilter.toModifier(mapping);
-        }).toList();
+  protected Container<BooleanExpression> valueAndModifierExpr(MappingContext mappingContext,
+      Mapping mapping,
+      IdentifierExpression identifier) {
+    var valueExpr = valueExpr(mappingContext, mapping, identifier);
+    var modifiers = Lists.concat(mapping.fixedCriteria(),
+        resolveAttributeModifiers(mapping.attributeMappings()));
+    if (Objects.nonNull(timeRestriction)) {
+      modifiers = Lists.concat(modifiers, List.of(timeRestriction.toModifier(mapping)));
     }
-
-    public TimeRestriction timeRestriction() {
-        return timeRestriction;
+    if (modifiers.isEmpty()) {
+      return valueExpr;
+    } else {
+      return Container.AND.apply(valueExpr, modifiersExpr(modifiers, mappingContext, identifier));
     }
+  }
+
+  abstract Container<BooleanExpression> valueExpr(MappingContext mappingContext, Mapping mapping,
+      IdentifierExpression identifier);
+
+  private List<Modifier> resolveAttributeModifiers(
+      Map<TermCode, AttributeMapping> attributeMappings) {
+    return attributeFilters.stream().map(attributeFilter -> {
+      var key = attributeFilter.attributeCode();
+      var mapping = Optional.ofNullable(attributeMappings.get(key)).orElseThrow(() ->
+          new MappingNotFoundException(key));
+      return attributeFilter.toModifier(mapping);
+    }).toList();
+  }
+
+  public TimeRestriction timeRestriction() {
+    return timeRestriction;
+  }
+
 }

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/ReferenceCriterion.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/ReferenceCriterion.java
@@ -1,0 +1,52 @@
+package de.numcodex.sq2cql.model.structured_query;
+
+import de.numcodex.sq2cql.Container;
+import de.numcodex.sq2cql.model.Mapping;
+import de.numcodex.sq2cql.model.MappingContext;
+import de.numcodex.sq2cql.model.common.TermCode;
+import de.numcodex.sq2cql.model.cql.BooleanExpression;
+import de.numcodex.sq2cql.model.cql.ExpressionDefinition;
+import de.numcodex.sq2cql.model.cql.IdentifierExpression;
+import de.numcodex.sq2cql.model.cql.InvocationExpression;
+import de.numcodex.sq2cql.model.cql.MembershipExpression;
+import de.numcodex.sq2cql.model.cql.QueryExpression;
+import de.numcodex.sq2cql.model.cql.RetrieveExpression;
+import de.numcodex.sq2cql.model.cql.ReturnClause;
+import de.numcodex.sq2cql.model.cql.SourceClause;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A {@code ReferenceCriterion} will select all patients that have at least one resource represented
+ * by that concept through a reference.
+ */
+public final class ReferenceCriterion extends AbstractCriterion {
+
+  private final TermCode referencedTermCode;
+
+  private ReferenceCriterion(Concept concept, List<AttributeFilter> attributeFilters,
+      TimeRestriction timeRestriction, TermCode referencedTermCode) {
+    super(concept, attributeFilters, timeRestriction);
+    this.referencedTermCode = referencedTermCode;
+
+  }
+
+  public static ReferenceCriterion from(AbstractCriterion criterion, TermCode referencedTermCode) {
+    return new ReferenceCriterion(criterion.concept, criterion.attributeFilters,
+        criterion.timeRestriction(), referencedTermCode);
+  }
+
+  @Override
+  Container<BooleanExpression> valueExpr(MappingContext mappingContext, Mapping mapping,
+      IdentifierExpression identifier) {
+    var valueExpr = InvocationExpression.of(identifier, mapping.valueFhirPath());
+    var codeSelector = codeSelector(mappingContext, referencedTermCode).getExpression();
+    var retrieveExpr = RetrieveExpression.of("Medication", codeSelector.get());
+    var query = QueryExpression.of(SourceClause.of(retrieveExpr, retrieveExpr.alias()),
+        ReturnClause.of(IdentifierExpression.of("'Medication/' + M.id")));
+    var defineExpr = new ExpressionDefinition("\"%s\"".formatted(referencedTermCode.display()), query);
+    return Container.of(
+        MembershipExpression.in(valueExpr, referenceName(mappingContext, referencedTermCode)),
+        Set.of(), Set.of(defineExpr));
+  }
+}

--- a/src/test/java/de/numcodex/sq2cql/AcceptanceTest.java
+++ b/src/test/java/de/numcodex/sq2cql/AcceptanceTest.java
@@ -104,7 +104,7 @@ public class AcceptanceTest {
     @MethodSource("de.numcodex.sq2cql.AcceptanceTest#getSqFileNames")
     public void runTestCase(String testCaseQueryName) throws Exception {
         var structuredQuery = readStructuredQuery(testCaseQueryName);
-        var cql = translator.toCql(structuredQuery).print(PrintContext.ZERO);
+        var cql = translator.toCql(structuredQuery).print();
         var measureUri = createMeasureAndLibrary(cql);
 
         var report = evaluateMeasure(measureUri);

--- a/src/test/java/de/numcodex/sq2cql/EvaluationIT.java
+++ b/src/test/java/de/numcodex/sq2cql/EvaluationIT.java
@@ -97,7 +97,7 @@ public class EvaluationIT {
         var translator = Translator.of(mappingContext);
         var criterion = NumericCriterion.of(Concept.of(BLOOD_PRESSURE), LESS_THAN, BigDecimal.valueOf(80), "mm[Hg]");
         var structuredQuery = StructuredQuery.of(List.of(List.of(criterion)));
-        var cql = translator.toCql(structuredQuery).print(PrintContext.ZERO);
+        var cql = translator.toCql(structuredQuery).print();
         var libraryUri = "urn:uuid" + UUID.randomUUID();
         var library = appendCql(parseResource(Library.class, slurp("Library.json")).setUrl(libraryUri), cql);
         var measureUri = "urn:uuid" + UUID.randomUUID();

--- a/src/test/java/de/numcodex/sq2cql/MedicationAdministrationTest.java
+++ b/src/test/java/de/numcodex/sq2cql/MedicationAdministrationTest.java
@@ -1,0 +1,91 @@
+package de.numcodex.sq2cql;
+
+import static java.util.Map.entry;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Functions;
+import de.numcodex.sq2cql.model.Mapping;
+import de.numcodex.sq2cql.model.MappingContext;
+import de.numcodex.sq2cql.model.TermCodeNode;
+import de.numcodex.sq2cql.model.structured_query.StructuredQuery;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+public class MedicationAdministrationTest {
+
+  private final Map<String, String> CODE_SYSTEM_ALIASES = Map.ofEntries(
+      entry("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "icd10"),
+      entry("http://loinc.org", "loinc"),
+      entry("https://fhir.bbmri.de/CodeSystem/SampleMaterialType", "sample"),
+      entry("http://fhir.de/CodeSystem/bfarm/atc", "atc"),
+      entry("http://snomed.info/sct", "snomed"),
+      entry("http://terminology.hl7.org/CodeSystem/condition-ver-status", "cvs"),
+      entry("http://hl7.org/fhir/administrative-gender", "gender"),
+      entry("https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/ecrf-parameter-codes",
+          "num-ecrf"), entry("urn:iso:std:iso:3166", "iso3166"),
+      entry("https://www.netzwerk-universitaetsmedizin.de/fhir/CodeSystem/frailty-score",
+          "fraility-score"),
+      entry("http://terminology.hl7.org/CodeSystem/consentcategorycodes", "consent"),
+      entry("urn:oid:2.16.840.1.113883.3.1937.777.24.5.1", "mide-1"),
+      entry("http://hl7.org/fhir/consent-provision-type", "provision-type"),
+      entry("http://fhir.de/CodeSystem/bfarm/ops", "oops"));
+
+  private static Path resourcePath(String name) throws URISyntaxException {
+    return Paths.get(Objects.requireNonNull(MedicationAdministrationTest.class.getResource(name)).toURI());
+  }
+
+  private static String slurp(String name) throws Exception {
+    return Files.readString(resourcePath(name));
+  }
+
+  private Translator createTranslator() throws Exception {
+    var mapper = new ObjectMapper();
+    var mappings = Arrays.stream(mapper.readValue(slurp("mapping.json"), Mapping[].class))
+        .collect(Collectors.toMap(Mapping::key, Functions.identity()));
+    var conceptTree = mapper.readValue(slurp("codex-code-tree.json"), TermCodeNode.class);
+    var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
+    return Translator.of(mappingContext);
+  }
+
+  @Test
+  public void translateMedicationAdministration() throws Exception {
+    var translator = createTranslator();
+    var structuredQuery = readStructuredQuery();
+    var cql = translator.toCql(structuredQuery).print(PrintContext.ZERO);
+    assertEquals("""
+        library Retrieve
+        using FHIR version '4.0.0'
+        include FHIRHelpers version '4.0.0'
+                
+        codesystem atc: 'http://fhir.de/CodeSystem/bfarm/atc'
+                
+        context Unfiltered
+                
+        define "Heparin":
+          [Medication: Code 'B01AB01' from atc] M
+            return 'Medication/' + M.id
+                
+        context Patient
+                
+        define InInitialPopulation:
+          exists (from [MedicationAdministration] M
+            where M.medication.reference in "Heparin")
+            """, cql);
+
+  }
+
+  private StructuredQuery readStructuredQuery() throws Exception {
+    return new com.fasterxml.jackson.databind.ObjectMapper().readValue(slurp(
+            "MedicationAdministration.json"),
+        StructuredQuery.class);
+  }
+
+}

--- a/src/test/java/de/numcodex/sq2cql/MedicationAdministrationTest.java
+++ b/src/test/java/de/numcodex/sq2cql/MedicationAdministrationTest.java
@@ -59,7 +59,7 @@ public class MedicationAdministrationTest {
   public void translateMedicationAdministration() throws Exception {
     var translator = createTranslator();
     var structuredQuery = readStructuredQuery();
-    var cql = translator.toCql(structuredQuery).print(PrintContext.ZERO);
+    var cql = translator.toCql(structuredQuery).print();
     assertEquals("""
         library Retrieve
         using FHIR version '4.0.0'
@@ -69,15 +69,15 @@ public class MedicationAdministrationTest {
                 
         context Unfiltered
                 
-        define "Heparin":
-          [Medication: Code 'B01AB01' from atc] M
+        define HeparinRef:
+          from [Medication: Code 'B01AB01' from atc] M
             return 'Medication/' + M.id
                 
         context Patient
                 
         define InInitialPopulation:
           exists (from [MedicationAdministration] M
-            where M.medication.reference in "Heparin")
+            where M.medication.reference in HeparinRef)
             """, cql);
 
   }

--- a/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
+++ b/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
@@ -211,7 +211,7 @@ class TranslatorTest {
                         
         define InInitialPopulation:
           exists [Condition: Code 'C71.1' from icd10]
-        """, library.print(PrintContext.ZERO));
+        """, library.print());
   }
 
   @Test
@@ -241,7 +241,7 @@ class TranslatorTest {
               exists (from [Condition: Code 'C71.1' from icd10] C
                 where C.onset as dateTime in Interval[@2020-01-01T, @2020-01-02T] or
                   C.onset overlaps Interval[@2020-01-01T, @2020-01-02T])
-            """, library.print(PrintContext.ZERO));
+            """, library.print());
   }
 
   @Test
@@ -303,7 +303,7 @@ class TranslatorTest {
               exists (from [Observation: Code '26515-7' from loinc] O
                 where O.value as Quantity < 50 'g/dl') and
               exists [MedicationStatement: Code 'L01AX03' from atc]
-            """, library.print(PrintContext.ZERO));
+            """, library.print());
   }
 
   @Test
@@ -349,7 +349,7 @@ class TranslatorTest {
             define InInitialPopulation:
               Inclusion and
               not Exclusion
-            """, library.print(PrintContext.ZERO));
+            """, library.print());
   }
 
   @Test
@@ -401,6 +401,6 @@ class TranslatorTest {
             define InInitialPopulation:
               Inclusion and
               not Exclusion
-            """, library.print(PrintContext.ZERO));
+            """, library.print());
   }
 }

--- a/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
+++ b/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
@@ -89,7 +89,7 @@ class TranslatorTest {
         List.of(List.of(Criterion.TRUE))));
 
     assertEquals("true",
-        library.expressionDefinitions().get(0).getExpression().print(PrintContext.ZERO));
+        library.contexts().get(0).expressionDefinitions().get(0).getExpression().print(PrintContext.ZERO));
   }
 
   @Test
@@ -97,7 +97,7 @@ class TranslatorTest {
     Library library = Translator.of().toCql(StructuredQuery.of(
         List.of(List.of(Criterion.TRUE, Criterion.FALSE))));
 
-    assertEquals("true or\nfalse", library.expressionDefinitions().get(0).getExpression()
+    assertEquals("true or\nfalse", library.contexts().get(0).expressionDefinitions().get(0).getExpression()
         .print(PrintContext.ZERO));
   }
 
@@ -106,7 +106,7 @@ class TranslatorTest {
     Library library = Translator.of().toCql(StructuredQuery.of(
         List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE))));
 
-    assertEquals("true and\nfalse", library.expressionDefinitions().get(0).getExpression()
+    assertEquals("true and\nfalse", library.contexts().get(0).expressionDefinitions().get(0).getExpression()
         .print(PrintContext.ZERO));
   }
 
@@ -116,7 +116,7 @@ class TranslatorTest {
         List.of(List.of(Criterion.TRUE, Criterion.TRUE),
             List.of(Criterion.FALSE, Criterion.FALSE))));
 
-    assertEquals("(true or\ntrue) and\n(false or\nfalse)", library.expressionDefinitions().get(0)
+    assertEquals("(true or\ntrue) and\n(false or\nfalse)", library.contexts().get(0).expressionDefinitions().get(0)
         .getExpression().print(PrintContext.ZERO));
   }
 
@@ -127,9 +127,9 @@ class TranslatorTest {
         List.of(List.of(Criterion.FALSE))));
 
     assertEquals("define Inclusion:\n  true",
-        library.expressionDefinitions().get(0).print(PrintContext.ZERO));
+        library.contexts().get(0).expressionDefinitions().get(0).print(PrintContext.ZERO));
     assertEquals("define Exclusion:\n  false",
-        library.expressionDefinitions().get(1).print(PrintContext.ZERO));
+        library.contexts().get(0).expressionDefinitions().get(1).print(PrintContext.ZERO));
   }
 
   @Test
@@ -138,7 +138,7 @@ class TranslatorTest {
         List.of(List.of(Criterion.TRUE)),
         List.of(List.of(Criterion.TRUE, Criterion.FALSE))));
 
-    assertEquals("define Exclusion:\n  true and\n  false", library.expressionDefinitions().get(1)
+    assertEquals("define Exclusion:\n  true and\n  false", library.contexts().get(0).expressionDefinitions().get(1)
         .print(PrintContext.ZERO));
   }
 
@@ -148,7 +148,7 @@ class TranslatorTest {
         List.of(List.of(Criterion.TRUE)),
         List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE))));
 
-    assertEquals("true or\nfalse", library.expressionDefinitions().get(1).getExpression()
+    assertEquals("true or\nfalse", library.contexts().get(0).expressionDefinitions().get(1).getExpression()
         .print(PrintContext.ZERO));
   }
 
@@ -159,7 +159,7 @@ class TranslatorTest {
         List.of(List.of(Criterion.TRUE, Criterion.TRUE),
             List.of(Criterion.FALSE, Criterion.FALSE))));
 
-    assertEquals("true and\ntrue or\nfalse and\nfalse", library.expressionDefinitions().get(1)
+    assertEquals("true and\ntrue or\nfalse and\nfalse", library.contexts().get(0).expressionDefinitions().get(1)
         .getExpression().print(PrintContext.ZERO));
   }
 

--- a/src/test/java/de/numcodex/sq2cql/model/cql/IdentifierExpressionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/IdentifierExpressionTest.java
@@ -1,0 +1,22 @@
+package de.numcodex.sq2cql.model.cql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import de.numcodex.sq2cql.PrintContext;
+import org.junit.jupiter.api.Test;
+
+public class IdentifierExpressionTest {
+
+  @Test
+  public void print_StringWithUnsupportedChars() {
+    var expr = IdentifierExpression.of("Test Expression-123");
+    assertEquals("\"Test Expression-123\"", expr.print(PrintContext.ZERO));
+  }
+
+  @Test
+  public void print_StringWithSupportedChars() {
+    var expr = IdentifierExpression.of("Test_Expression123");
+    assertEquals("Test_Expression123", expr.print(PrintContext.ZERO));
+  }
+
+}

--- a/src/test/java/de/numcodex/sq2cql/model/cql/LibraryTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/LibraryTest.java
@@ -16,7 +16,7 @@ class LibraryTest {
 
     @Test
     void print_Empty() {
-        var cql = Library.of().print(PrintContext.ZERO);
+        var cql = Library.of().print();
 
         assertEquals("""
                 library Retrieve
@@ -30,7 +30,7 @@ class LibraryTest {
     @Test
     void print_OnExpressionDefinition() {
         var cql = Library.of(Set.of(), List.of(Context.of("Patient", List.of(ExpressionDefinition.of("InInitialPopulation", TRUE)))))
-                .print(PrintContext.ZERO);
+                .print();
 
         assertEquals("""
                 library Retrieve

--- a/src/test/java/de/numcodex/sq2cql/model/cql/LibraryTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/LibraryTest.java
@@ -22,16 +22,14 @@ class LibraryTest {
                 library Retrieve
                 using FHIR version '4.0.0'
                 include FHIRHelpers version '4.0.0'
-                                
-                context Patient
-                                
+                                                                
                                 
                 """, cql);
     }
 
     @Test
     void print_OnExpressionDefinition() {
-        var cql = Library.of(Set.of(), List.of(ExpressionDefinition.of("InInitialPopulation", TRUE)))
+        var cql = Library.of(Set.of(), List.of(Context.of("Patient", List.of(ExpressionDefinition.of("InInitialPopulation", TRUE)))))
                 .print(PrintContext.ZERO);
 
         assertEquals("""

--- a/src/test/java/de/numcodex/sq2cql/model/cql/QueryExpressionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/QueryExpressionTest.java
@@ -31,7 +31,7 @@ class QueryExpressionTest {
 
     static QueryExpression query() {
         var retrieve = RetrieveExpression.of("Observation", CodeSelector.of("85354-9", "loinc"));
-        var sourceClause = SourceClause.of(retrieve, IdentifierExpression.of("O"));
+        var sourceClause = SourceClause.from(retrieve, IdentifierExpression.of("O"));
         return QueryExpression.of(sourceClause, WhereClause.of(BooleanExpression.TRUE));
     }
 }

--- a/src/test/java/de/numcodex/sq2cql/model/cql/QueryExpressionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/QueryExpressionTest.java
@@ -31,7 +31,7 @@ class QueryExpressionTest {
 
     static QueryExpression query() {
         var retrieve = RetrieveExpression.of("Observation", CodeSelector.of("85354-9", "loinc"));
-        var sourceClause = SourceClause.from(retrieve, IdentifierExpression.of("O"));
+        var sourceClause = SourceClause.of(retrieve, IdentifierExpression.of("O"));
         return QueryExpression.of(sourceClause, WhereClause.of(BooleanExpression.TRUE));
     }
 }

--- a/src/test/resources/de/numcodex/sq2cql/MedicationAdministration.json
+++ b/src/test/resources/de/numcodex/sq2cql/MedicationAdministration.json
@@ -1,0 +1,17 @@
+{
+  "version": "http://to_be_decided.com/draft-1/schema#",
+  "inclusionCriteria": [
+    [
+      {
+        "termCodes": [
+          {
+            "code": "B01AB01",
+            "system": "http://fhir.de/CodeSystem/bfarm/atc",
+            "version": "2021",
+            "display": "Enoxaparin natrium"
+          }
+        ]
+      }
+    ]
+  ]
+}

--- a/src/test/resources/de/numcodex/sq2cql/mapping.json
+++ b/src/test/resources/de/numcodex/sq2cql/mapping.json
@@ -1,31 +1,14 @@
-
+[
   {
     "fhirResourceType": "MedicationAdministration",
-    "fixedCriteria": [
-      {
-        "fhirPath": "status",
-        "searchParameter": "status",
-        "type": "code",
-        "value": [
-          {
-            "code": "active",
-            "display": "active",
-            "system": "http://hl7.org/fhir/CodeSystem/medication-admin-status"
-          },
-          {
-            "code": "completed",
-            "display": "completed",
-            "system": "http://hl7.org/fhir/CodeSystem/medication-admin-status"
-          }
-        ]
-      }
-    ],
     "key": {
-      "code": "V09IB03",
-      "display": "(111In)Indium Antiovariumkarzinomantik\u00f6rper",
+      "code": "B01AB01",
       "system": "http://fhir.de/CodeSystem/bfarm/atc",
-      "version": "2021"
+      "version": "2021",
+      "display": "Heparin"
     },
     "termCodeSearchParameter": "code",
-    "timeRestrictionParameter": "effective-time"
+    "timeRestrictionParameter": "effective-time",
+    "valueFhirPath": "medication.reference"
   }
+]


### PR DESCRIPTION
To support codes via reference i.e. MedicationAdministration which
references a Medication, and we are interested in the code of the medication
ReferenceCriterion is introduced. The necessary Define statements to refer to
are collected using the Container class and are displayed in the Undefined
Context above the Patient Context. This is a first working Version, with
hardcoded path for MedicationAdministration. Long term an additional mapping
type is required, or expressing support for more complex valueFhirPath like:
MS.medication.as(Reference).resolve().as(Medication).code.
Make sure you have a mapping version with valueFhirPath=Medication.reference
for MedicationAdministration.