### PR TITLE
Quick and dirty solution to set library version to 1.0.0 for HAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Library library = Translator.of(mappingContext).toCql(StructuredQuery.of(List.of
         List.of(ConceptCriterion.of(c71_1)))));
 
 assertEquals("""
-        library Retrieve
+        library Retrieve version '1.0.0'
         using FHIR version '4.0.0'
         include FHIRHelpers version '4.0.0'
                                            

--- a/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
+++ b/src/main/java/de/numcodex/sq2cql/model/cql/Library.java
@@ -31,7 +31,7 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
     public String print() {
         return codeSystemDefinitions.isEmpty()
                 ? """
-                library Retrieve
+                library Retrieve version '1.0.0'
                 using FHIR version '4.0.0'
                 include FHIRHelpers version '4.0.0'
                                       
@@ -39,7 +39,7 @@ public record Library(Set<CodeSystemDefinition> codeSystemDefinitions,
                 """
                 .formatted(contexts.stream().map(Context::print).collect(joining("\n\n")))
                 : """
-                library Retrieve
+                library Retrieve version '1.0.0'
                 using FHIR version '4.0.0'
                 include FHIRHelpers version '4.0.0'
                                 

--- a/src/test/java/de/numcodex/sq2cql/MedicationAdministrationTest.java
+++ b/src/test/java/de/numcodex/sq2cql/MedicationAdministrationTest.java
@@ -61,7 +61,7 @@ public class MedicationAdministrationTest {
     var structuredQuery = readStructuredQuery();
     var cql = translator.toCql(structuredQuery).print();
     assertEquals("""
-        library Retrieve
+        library Retrieve version '1.0.0'
         using FHIR version '4.0.0'
         include FHIRHelpers version '4.0.0'
                 

--- a/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
+++ b/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
@@ -201,7 +201,7 @@ class TranslatorTest {
         List.of(ConceptCriterion.of(Concept.of(c71_1))))));
 
     assertEquals("""
-        library Retrieve
+        library Retrieve version '1.0.0'
         using FHIR version '4.0.0'
         include FHIRHelpers version '4.0.0'
                                            
@@ -229,7 +229,7 @@ class TranslatorTest {
             TimeRestriction.of("2020-01-01T", "2020-01-02T"))))));
 
     assertEquals("""
-            library Retrieve
+            library Retrieve version '1.0.0'
             using FHIR version '4.0.0'
             include FHIRHelpers version '4.0.0'
                                                
@@ -284,7 +284,7 @@ class TranslatorTest {
     Library library = Translator.of(mappingContext).toCql(structuredQuery);
 
     assertEquals("""
-            library Retrieve
+            library Retrieve version '1.0.0'
             using FHIR version '4.0.0'
             include FHIRHelpers version '4.0.0'
 
@@ -327,7 +327,7 @@ class TranslatorTest {
     Library library = Translator.of(mappingContext).toCql(structuredQuery);
 
     assertEquals("""
-            library Retrieve
+            library Retrieve version '1.0.0'
             using FHIR version '4.0.0'
             include FHIRHelpers version '4.0.0'
 
@@ -373,7 +373,7 @@ class TranslatorTest {
     Library library = Translator.of(mappingContext).toCql(structuredQuery);
 
     assertEquals("""
-            library Retrieve
+            library Retrieve version '1.0.0'
             using FHIR version '4.0.0'
             include FHIRHelpers version '4.0.0'
 

--- a/src/test/java/de/numcodex/sq2cql/model/cql/LibraryTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/cql/LibraryTest.java
@@ -19,7 +19,7 @@ class LibraryTest {
         var cql = Library.of().print();
 
         assertEquals("""
-                library Retrieve
+                library Retrieve version '1.0.0'
                 using FHIR version '4.0.0'
                 include FHIRHelpers version '4.0.0'
                                                                 
@@ -33,7 +33,7 @@ class LibraryTest {
                 .print();
 
         assertEquals("""
-                library Retrieve
+                library Retrieve version '1.0.0'
                 using FHIR version '4.0.0'
                 include FHIRHelpers version '4.0.0'
                                 


### PR DESCRIPTION
Quick and dirty solution to set library version to 1.0.0 for HAPI