### PR TITLE
Add primaryCode to Mapping to model MII Consent

### DIFF
--- a/src/main/java/de/numcodex/sq2cql/model/Mapping.java
+++ b/src/main/java/de/numcodex/sq2cql/model/Mapping.java
@@ -27,9 +27,10 @@ public final class Mapping {
     private final List<Modifier> fixedCriteria;
     private final Map<TermCode, AttributeMapping> attributeMappings;
     private final String timeRestrictionPath;
+    private final TermCode primaryCode;
 
     public Mapping(TermCode key, String resourceType, String valueFhirPath, String valueType, List<Modifier> fixedCriteria,
-        List<AttributeMapping> attributeMappings, String timeRestrictionPath) {
+        List<AttributeMapping> attributeMappings, String timeRestrictionPath, TermCode primaryCode) {
         this.key = requireNonNull(key);
         this.resourceType = requireNonNull(resourceType);
         this.valueFhirPath = requireNonNull(valueFhirPath);
@@ -38,24 +39,31 @@ public final class Mapping {
         this.attributeMappings = (attributeMappings == null ? Map.of() : attributeMappings.stream()
                 .collect(Collectors.toMap(AttributeMapping::key, Function.identity())));
         this.timeRestrictionPath = timeRestrictionPath;
+        this.primaryCode = primaryCode;
     }
 
     public static Mapping of(TermCode key, String resourceType) {
-        return new Mapping(key, resourceType, "value", null, List.of(), List.of(), null);
+        return new Mapping(key, resourceType, "value", null, List.of(), List.of(), null, null);
     }
 
     public static Mapping of(TermCode concept, String resourceType, String valueFhirPath) {
-        return new Mapping(concept, resourceType, valueFhirPath, null, List.of(), List.of(), null);
+        return new Mapping(concept, resourceType, valueFhirPath, null, List.of(), List.of(), null, null);
     }
 
     public static Mapping of(TermCode concept, String resourceType, String valueFhirPath, String valueType) {
-        return new Mapping(concept, resourceType, valueFhirPath, valueType, List.of(), List.of(), null);
+        return new Mapping(concept, resourceType, valueFhirPath, valueType, List.of(), List.of(), null, null);
     }
 
     public static Mapping of(TermCode key, String resourceType, String valueFhirPath, String valueType, List<Modifier> fixedCriteria,List<AttributeMapping> attributeMappings) {
         return new Mapping(key, resourceType, valueFhirPath == null ? "value" : valueFhirPath, valueType,
             fixedCriteria == null ? List.of() : List.copyOf(fixedCriteria),
-            attributeMappings, null);
+            attributeMappings, null, null);
+    }
+
+    public static Mapping of(TermCode key, String resourceType, String valueFhirPath, String valueType, List<Modifier> fixedCriteria, List<AttributeMapping> attributeMappings, String timeRestrictionPath) {
+        return new Mapping(key, resourceType, valueFhirPath == null ? "value" : valueFhirPath, valueType,
+            fixedCriteria == null ? List.of() : List.copyOf(fixedCriteria),
+            attributeMappings, timeRestrictionPath, null);
     }
 
     @JsonCreator
@@ -65,10 +73,11 @@ public final class Mapping {
                              @JsonProperty("valueType") String valueType,
                              @JsonProperty("fixedCriteria") List<Modifier> fixedCriteria,
                              @JsonProperty("attributeSearchParameters") List<AttributeMapping> attributeMappings,
-                             @JsonProperty("timeRestrictionPath") String timeRestrictionPath) {
+                             @JsonProperty("timeRestrictionPath") String timeRestrictionPath,
+                             @JsonProperty("primaryCode") TermCode primaryCode) {
         return new Mapping(key, resourceType, valueFhirPath == null ? "value" : valueFhirPath, valueType,
                 fixedCriteria == null ? List.of() : List.copyOf(fixedCriteria),
-                attributeMappings, timeRestrictionPath);
+                attributeMappings, timeRestrictionPath, primaryCode);
     }
 
     public TermCode key() {
@@ -97,5 +106,17 @@ public final class Mapping {
 
     public Optional<String> timeRestrictionPath() {
         return Optional.ofNullable(timeRestrictionPath);
+    }
+
+    /**
+     * Returns the primary code of this mapping. The primary code is used in the retrieve CQL
+     * expression to identify the resources of interest. The path for the primary code path is
+     * implicitly given in CQL but can be looked up at https://github.com/cqframework/clinical_quality_language/blob/master/Src/java/quick/src/main/resources/org/hl7/fhir/fhir-modelinfo-4.0.1.xml
+     *
+     * @return the primary code of this mapping or the key if no primary code is defined
+     */
+    public TermCode primaryCode() {
+      // TODO: decouple key and primary code. The key should only be used for the mapping lookup.
+      return primaryCode == null ? key : primaryCode;
     }
 }

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/AbstractCriterion.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/AbstractCriterion.java
@@ -80,11 +80,11 @@ abstract class AbstractCriterion implements Criterion {
    */
   static Container<RetrieveExpression> retrieveExpr(MappingContext mappingContext,
       TermCode termCode) {
-    return codeSelector(mappingContext, termCode).map(terminology -> {
-      var mapping = mappingContext.findMapping(termCode)
-          .orElseThrow(() -> new MappingNotFoundException(termCode));
-      return RetrieveExpression.of(mapping.resourceType(), terminology);
-    });
+    var mapping = mappingContext.findMapping(termCode)
+        .orElseThrow(() -> new MappingNotFoundException(termCode));
+    // TODO if no primary code retrieve all resources
+    return codeSelector(mappingContext, mapping.primaryCode()).map(terminology ->
+        RetrieveExpression.of(mapping.resourceType(), terminology));
   }
 
 


### PR DESCRIPTION
The retrieve expression now always uses the primaryCode of the mapping, which currently returns the primaryCode if present or else the key. Future versions will decouple the key and the primaryCode.