### PR TITLE
Bugfixes for November release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <hapi-fhir.version>6.8.5</hapi-fhir.version>
         <testcontainers.version>1.18.3</testcontainers.version>
         <slf4j.version>2.0.9</slf4j.version>
-        <ontology.version>2.1.18-RC</ontology.version>
+        <ontology.version>2.1.22-RC</ontology.version>
     </properties>
 
     <dependencies>

--- a/src/main/java/de/numcodex/sq2cql/model/Mapping.java
+++ b/src/main/java/de/numcodex/sq2cql/model/Mapping.java
@@ -27,12 +27,12 @@ public final class Mapping {
     private final String valueType;
     private final List<Modifier> fixedCriteria;
     private final Map<TermCode, AttributeMapping> attributeMappings;
-    private final String timeRestrictionPath;
+    private final String timeRestrictionFhirPath;
     private final TermCode primaryCode;
     private final String termCodeFhirPath;
 
     public Mapping(ContextualTermCode key, String resourceType, String valueFhirPath, String valueType, List<Modifier> fixedCriteria,
-                   List<AttributeMapping> attributeMappings, String timeRestrictionPath, TermCode primaryCode, String termCodeFhirPath) {
+                   List<AttributeMapping> attributeMappings, String timeRestrictionFhirPath, TermCode primaryCode, String termCodeFhirPath) {
         this.key = requireNonNull(key);
         this.resourceType = requireNonNull(resourceType);
         this.valueFhirPath = valueFhirPath;
@@ -40,7 +40,7 @@ public final class Mapping {
         this.fixedCriteria = List.copyOf(fixedCriteria);
         this.attributeMappings = (attributeMappings == null ? Map.of() : attributeMappings.stream()
                 .collect(Collectors.toMap(AttributeMapping::key, Function.identity())));
-        this.timeRestrictionPath = timeRestrictionPath;
+        this.timeRestrictionFhirPath = timeRestrictionFhirPath;
         this.primaryCode = primaryCode;
         this.termCodeFhirPath = termCodeFhirPath;
     }
@@ -63,10 +63,10 @@ public final class Mapping {
                 attributeMappings, null, null, null);
     }
 
-    public static Mapping of(ContextualTermCode key, String resourceType, String valueFhirPath, String valueType, List<Modifier> fixedCriteria, List<AttributeMapping> attributeMappings, String timeRestrictionPath) {
+    public static Mapping of(ContextualTermCode key, String resourceType, String valueFhirPath, String valueType, List<Modifier> fixedCriteria, List<AttributeMapping> attributeMappings, String timeRestrictionFhirPath) {
         return new Mapping(key, resourceType, valueFhirPath == null ? "value" : valueFhirPath, valueType,
                 fixedCriteria == null ? List.of() : List.copyOf(fixedCriteria),
-                attributeMappings, timeRestrictionPath, null, null);
+                attributeMappings, timeRestrictionFhirPath, null, null);
     }
 
     @JsonCreator
@@ -77,7 +77,7 @@ public final class Mapping {
                              @JsonProperty("valueType") String valueType,
                              @JsonProperty("fixedCriteria") List<Modifier> fixedCriteria,
                              @JsonProperty("attributeFhirPaths") List<AttributeMapping> attributeMappings,
-                             @JsonProperty("timeRestrictionPath") String timeRestrictionPath,
+                             @JsonProperty("timeRestrictionFhirPath") String timeRestrictionFhirPath,
                              @JsonProperty("primaryCode") TermCode primaryCode,
                              @JsonProperty("termCodeFhirPath") String termCodeFhirPath) {
         var contextualTermCode = ContextualTermCode.of(context, key);
@@ -87,7 +87,7 @@ public final class Mapping {
                 valueType,
                 fixedCriteria == null ? List.of() : List.copyOf(fixedCriteria),
                 attributeMappings,
-                timeRestrictionPath,
+                timeRestrictionFhirPath,
                 primaryCode,
                 termCodeFhirPath);
     }
@@ -116,8 +116,8 @@ public final class Mapping {
         return attributeMappings;
     }
 
-    public Optional<String> timeRestrictionPath() {
-        return Optional.ofNullable(timeRestrictionPath);
+    public Optional<String> timeRestrictionFhirPath() {
+        return Optional.ofNullable(timeRestrictionFhirPath);
     }
 
     /**

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/CodingModifier.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/CodingModifier.java
@@ -29,7 +29,7 @@ public record CodingModifier(String path, List<TermCode> concepts) implements Si
 
     @Override
     public Container<BooleanExpression> expression(MappingContext mappingContext, IdentifierExpression sourceAlias) {
-        var codingExpr = InvocationExpression.of(InvocationExpression.of(sourceAlias, path), "coding");
+        var codingExpr = InvocationExpression.of(sourceAlias, path);
         return concepts.stream()
                 .map(concept -> codeSelector(mappingContext, concept).map(terminology ->
                         (BooleanExpression) MembershipExpression.contains(codingExpr, terminology)))

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/Modifier.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/Modifier.java
@@ -32,7 +32,7 @@ public interface Modifier {
         if ("code".equals(type)) {
             return CodeModifier.of(path, Stream.of(values).map(TermCode::fromJsonNode).map(TermCode::code).toArray(String[]::new));
         }
-        if ("coding".equals(type)) {
+        if ("Coding".equals(type)) {
             return CodingModifier.of(path, Stream.of(values).map(TermCode::fromJsonNode).toArray(TermCode[]::new));
         }
         throw new IllegalArgumentException("unknown type: " + type);

--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/TimeRestriction.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/TimeRestriction.java
@@ -26,8 +26,8 @@ public record TimeRestriction(String afterDate, String beforeDate) {
     }
 
     public Modifier toModifier(Mapping mapping) {
-        var path = mapping.timeRestrictionPath()
-                .orElseThrow(() -> new IllegalStateException("Missing timeRestrictionPath in mapping with key %s."
+        var path = mapping.timeRestrictionFhirPath()
+                .orElseThrow(() -> new IllegalStateException("Missing timeRestrictionFhirPath in mapping with key %s."
                         .formatted(mapping.key())));
         return TimeRestrictionModifier.of(path, afterDate, beforeDate);
     }

--- a/src/test/java/de/numcodex/sq2cql/SpecimenTest.java
+++ b/src/test/java/de/numcodex/sq2cql/SpecimenTest.java
@@ -176,7 +176,7 @@ public class SpecimenTest {
                   exists (from [Specimen: Code '119364003' from snomed] S
                     with "Diagnose E13.9" C
                       such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
-                    where S.collection.bodySite.coding.coding contains Code 'C44.6' from icd-o-3)
+                    where S.collection.bodySite.coding contains Code 'C44.6' from icd-o-3)
                     """, cql);
     }
 

--- a/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
+++ b/src/test/java/de/numcodex/sq2cql/TranslatorTest.java
@@ -83,7 +83,7 @@ class TranslatorTest {
     static final TermCode VERIFICATION_STATUS = TermCode.of("hl7.org", "verificationStatus",
             "verificationStatus");
     static final AttributeMapping VERIFICATION_STATUS_ATTR_MAPPING = AttributeMapping.of("Coding",
-            VERIFICATION_STATUS, "verificationStatus");
+            VERIFICATION_STATUS, "verificationStatus.coding");
 
     @Test
     void toCQL_Inclusion_OneDisjunctionWithOneCriterion() {
@@ -263,7 +263,7 @@ class TranslatorTest {
         var translator = Translator.of(mappingContext);
 
         assertThatIllegalStateException().isThrownBy(() -> translator.toCql(query)).withMessage(
-                "Missing timeRestrictionPath in mapping with key ContextualTermCode[context=TermCode[system=context, code=context, display=context], termCode=TermCode[system=http://fhir.de/CodeSystem/bfarm/icd-10-gm, code=C71.1, display=Malignant neoplasm of brain]].");
+                "Missing timeRestrictionFhirPath in mapping with key ContextualTermCode[context=TermCode[system=context, code=context, display=context], termCode=TermCode[system=http://fhir.de/CodeSystem/bfarm/icd-10-gm, code=C71.1, display=Malignant neoplasm of brain]].");
     }
 
     @Test
@@ -356,9 +356,9 @@ class TranslatorTest {
     void toCQL_GeccoTask2() {
         var mappings = Map.of(FRAILTY_SCORE, Mapping.of(FRAILTY_SCORE, "Observation", "value"), COPD,
                 Mapping.of(COPD, "Condition", null, null,
-                        List.of(CodingModifier.of("verificationStatus", CONFIRMED)), List.of()), G47_31,
+                        List.of(CodingModifier.of("verificationStatus.coding", CONFIRMED)), List.of()), G47_31,
                 Mapping.of(G47_31, "Condition", null, null,
-                        List.of(CodingModifier.of("verificationStatus", CONFIRMED)), List.of()),
+                        List.of(CodingModifier.of("verificationStatus.coding", CONFIRMED)), List.of()),
                 TOBACCO_SMOKING_STATUS, Mapping.of(TOBACCO_SMOKING_STATUS, "Observation", "value"));
         var conceptTree = TermCodeNode.of(ROOT, TermCodeNode.of(COPD), TermCodeNode.of(G47_31));
         var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
@@ -425,9 +425,9 @@ class TranslatorTest {
                                 ]
                             },
                             {
-                                "fhirPath": "provision.provision.code",
+                                "fhirPath": "provision.provision.code.coding",
                                 "searchParameter": "mii-provision-provision-code",
-                                "type": "coding",
+                                "type": "Coding",
                                 "value": [
                                     {
                                         "code": "2.16.840.1.113883.3.1937.777.24.5.3.5",
@@ -437,9 +437,9 @@ class TranslatorTest {
                                 ]
                             },
                             {
-                                "fhirPath": "provision.provision.code",
+                                "fhirPath": "provision.provision.code.coding",
                                 "searchParameter": "mii-provision-provision-code",
-                                "type": "coding",
+                                "type": "Coding",
                                 "value": [
                                     {
                                         "code": "2.16.840.1.113883.3.1937.777.24.5.3.2",
@@ -465,7 +465,7 @@ class TranslatorTest {
                             "system": "http://loinc.org"
                         },
                         "timeRestrictionParameter": "date",
-                        "timeRestrictionPath": "dateTime"
+                        "timeRestrictionFhirPath": "dateTime"
                     }
                 """, Mapping.class);
         var structuredQuery = mapper.readValue("""

--- a/src/test/java/de/numcodex/sq2cql/model/MappingTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/MappingTest.java
@@ -123,13 +123,13 @@ class MappingTest {
                       },
                       "resourceType": "Observation",
                       "valueFhirPath": "value",
-                      "timeRestrictionPath": "effective"
+                      "timeRestrictionFhirPath": "effective"
                     }
                     """);
 
             assertThat(mapping.key()).isEqualTo(TC_2);
             assertThat(mapping.resourceType()).isEqualTo("Observation");
-            assertThat(mapping.timeRestrictionPath()).contains("effective");
+            assertThat(mapping.timeRestrictionFhirPath()).contains("effective");
         }
 
         @Nested
@@ -267,7 +267,7 @@ class MappingTest {
                           "resourceType": "Observation",
                           "fixedCriteria": [
                             {
-                              "type": "coding",
+                              "type": "Coding",
                               "searchParameter": "verification-status",
                               "fhirPath": "verificationStatus",
                               "value": [

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/CodingModifierTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/CodingModifierTest.java
@@ -25,7 +25,7 @@ class CodingModifierTest {
 
     @Test
     void expression() {
-        var modifier = CodingModifier.of("verificationStatus", CONFIRMED);
+        var modifier = CodingModifier.of("verificationStatus.coding", CONFIRMED);
 
         var expression = modifier.expression(MAPPING_CONTEXT, IdentifierExpression.of("C"));
 

--- a/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptCriterionTest.java
+++ b/src/test/java/de/numcodex/sq2cql/model/structured_query/ConceptCriterionTest.java
@@ -245,7 +245,7 @@ class ConceptCriterionTest {
     var criterion = ConceptCriterion.of(ContextualConcept.of(C71))
         .appendAttributeFilter(ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED));
     var mapping = Mapping.of(C71, "Condition", null, null, List.of(),
-        List.of(AttributeMapping.of("Coding", VERIFICATION_STATUS, "verificationStatus")));
+        List.of(AttributeMapping.of("Coding", VERIFICATION_STATUS, "verificationStatus.coding")));
     var mappingContext = MappingContext.of(Map.of(C71, mapping), TermCodeNode.of(C71),
         CODE_SYSTEM_ALIASES);
 
@@ -264,9 +264,9 @@ class ConceptCriterionTest {
     var criterion = ConceptCriterion.of(ContextualConcept.of(C71))
         .appendAttributeFilter(ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED));
     var mapping1 = Mapping.of(C71_1, "Condition", null, null, List.of(),
-        List.of(AttributeMapping.of("Coding", VERIFICATION_STATUS, "verificationStatus")));
+        List.of(AttributeMapping.of("Coding", VERIFICATION_STATUS, "verificationStatus.coding")));
     var mapping2 = Mapping.of(C71_2, "Condition", null, null, List.of(),
-        List.of(AttributeMapping.of("Coding", VERIFICATION_STATUS, "verificationStatus")));
+        List.of(AttributeMapping.of("Coding", VERIFICATION_STATUS, "verificationStatus.coding")));
     var mappingContext = MappingContext.of(Map.of(C71_1, mapping1, C71_2, mapping2),
         TermCodeNode.of(C71, TermCodeNode.of(C71_1), TermCodeNode.of(C71_2)), CODE_SYSTEM_ALIASES);
 
@@ -323,7 +323,7 @@ class ConceptCriterionTest {
   void toCql_FixedCriteria_Coding() {
     var criterion = ConceptCriterion.of(ContextualConcept.of(C71));
     var mappingContext = MappingContext.of(Map.of(C71, Mapping.of(C71, "Condition", null, null,
-            List.of(CodingModifier.of("verificationStatus", CONFIRMED)), List.of())),
+            List.of(CodingModifier.of("verificationStatus.coding", CONFIRMED)), List.of())),
         TermCodeNode.of(C71), CODE_SYSTEM_ALIASES);
 
     var container = criterion.toCql(mappingContext);


### PR DESCRIPTION
- Updated Ontology version to 2.1.22-RC.
- The path of Modifiers of type "Coding" no longer have an invocation of ".coding"
- timeRestrictionPath -> timeRestrictionFhirPath matching the mapping
- Fixed Specimen Testcase