### PR TITLE
Fix Reference Comparison for Multi-Valued Paths

### DIFF
--- a/src/main/java/de/numcodex/sq2cql/model/structured_query/ReferenceModifier.java
+++ b/src/main/java/de/numcodex/sq2cql/model/structured_query/ReferenceModifier.java
@@ -29,7 +29,7 @@ public record ReferenceModifier(String path, String targetType, List<Criterion> 
                     var referenceExpr = InvocationExpression.of(query.sourceAlias(), path);
                     var alias = StandardIdentifierExpression.of(targetType.substring(0, 1));
                     var ref = AdditionExpressionTerm.of(StringLiteralExpression.of(targetType + "/"), InvocationExpression.of(alias, "id"));
-                    var comparatorExpr = ComparatorExpression.equal(referenceExpr, ref);
+                    var comparatorExpr = MembershipExpression.contains(referenceExpr, ref);
                     return query.appendQueryInclusionClause(WithClause.of(AliasedQuerySource.of(referencesExprName, alias), comparatorExpr));
                 }));
     }

--- a/src/test/java/de/numcodex/sq2cql/EvaluationIT.java
+++ b/src/test/java/de/numcodex/sq2cql/EvaluationIT.java
@@ -50,7 +50,7 @@ public class EvaluationIT {
     static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of("http://loinc.org", "loinc");
 
     @Container
-    private final GenericContainer<?> blaze = new GenericContainer<>(DockerImageName.parse("samply/blaze:0.27"))
+    private final GenericContainer<?> blaze = new GenericContainer<>(DockerImageName.parse("samply/blaze:0.28"))
             .withImagePullPolicy(PullPolicy.alwaysPull())
             .withExposedPorts(8080)
             .waitingFor(Wait.forHttp("/health").forStatusCode(200))

--- a/src/test/java/de/numcodex/sq2cql/SpecimenTest.java
+++ b/src/test/java/de/numcodex/sq2cql/SpecimenTest.java
@@ -52,25 +52,25 @@ public class SpecimenTest {
                 define Criterion:
                   exists (from [Specimen: Code '119364003' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '258590006' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866034009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '2421000181104' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866035005' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '442427000' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '737089009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id)
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id)
                 
                 define InInitialPopulation:
                   Criterion
@@ -108,25 +108,25 @@ public class SpecimenTest {
                 define "Criterion 2":
                   exists (from [Specimen: Code '119364003' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '258590006' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866034009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '2421000181104' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866035005' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '442427000' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '737089009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id)
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id)
                 
                 define Exclusion:
                   "Criterion 2"
@@ -165,25 +165,25 @@ public class SpecimenTest {
                 define "Criterion 2":
                   exists (from [Specimen: Code '119364003' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '258590006' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866034009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '2421000181104' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866035005' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '442427000' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '737089009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id)
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id)
                 
                 define InInitialPopulation:
                   "Criterion 1" and
@@ -218,25 +218,25 @@ public class SpecimenTest {
                 define Criterion:
                   exists (from [Specimen: Code '119364003' from snomed] S
                     with "Diagnose E13.9 and Diagnose E13.1" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '258590006' from snomed] S
                     with "Diagnose E13.9 and Diagnose E13.1" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866034009' from snomed] S
                     with "Diagnose E13.9 and Diagnose E13.1" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '2421000181104' from snomed] S
                     with "Diagnose E13.9 and Diagnose E13.1" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '866035005' from snomed] S
                     with "Diagnose E13.9 and Diagnose E13.1" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '442427000' from snomed] S
                     with "Diagnose E13.9 and Diagnose E13.1" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id) or
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id) or
                   exists (from [Specimen: Code '737089009' from snomed] S
                     with "Diagnose E13.9 and Diagnose E13.1" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id)
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id)
                 
                 define InInitialPopulation:
                   Criterion
@@ -269,31 +269,31 @@ public class SpecimenTest {
                 define Criterion:
                   exists (from [Specimen: Code '119364003' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id
                     where S.collection.bodySite.coding contains Code 'C44.6' from icd_o_3) or
                   exists (from [Specimen: Code '258590006' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id
                     where S.collection.bodySite.coding contains Code 'C44.6' from icd_o_3) or
                   exists (from [Specimen: Code '866034009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id
                     where S.collection.bodySite.coding contains Code 'C44.6' from icd_o_3) or
                   exists (from [Specimen: Code '2421000181104' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id
                     where S.collection.bodySite.coding contains Code 'C44.6' from icd_o_3) or
                   exists (from [Specimen: Code '866035005' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id
                     where S.collection.bodySite.coding contains Code 'C44.6' from icd_o_3) or
                   exists (from [Specimen: Code '442427000' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id
                     where S.collection.bodySite.coding contains Code 'C44.6' from icd_o_3) or
                   exists (from [Specimen: Code '737089009' from snomed] S
                     with "Diagnose E13.9" C
-                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference = 'Condition/' + C.id
+                      such that S.extension.where(url='https://www.medizininformatik-initiative.de/fhir/ext/modul-biobank/StructureDefinition/Diagnose').first().value.as(Reference).reference contains 'Condition/' + C.id
                     where S.collection.bodySite.coding contains Code 'C44.6' from icd_o_3)
                 
                 define InInitialPopulation:


### PR DESCRIPTION
I just use `contains` everywhere because FHIRPath expressions return a list anyway.

Closes: #119