### PR TITLE
Add relative time / anchor support to StructuredQuery

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ var codeSystemAliases = Map.of("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "icd
 var mappingContext = MappingContext.of(mappings, conceptTree, codeSystemAliases);
 
 Library library = Translator.of(mappingContext).toCql(StructuredQuery.of(List.of(
-        List.of(ConceptCriterion.of(c71_1)))));
+        Group.of(List.of(List.of(ConceptCriterion.of(c71_1)))))));
 
 assertEquals("""
         library Retrieve version '1.0.0'
@@ -34,7 +34,7 @@ assertEquals("""
 ```
 var mapper = new ObjectMapper();
 mapper.readValue("""
-        {"inclusionCriteria": [[{
+        {"inclusionCriteria": [{"criteria": [[{
           "termCodes": [{
             "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm", 
             "code": "C71.1",
@@ -61,7 +61,7 @@ mapper.readValue("""
               }
             ]
           }
-        }]]}
+        }]]}]}
         """, StructuredQuery.class);
 ```
 

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/Translator.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/Translator.java
@@ -4,11 +4,14 @@ import de.medizininformatikinitiative.cctb.model.MappingContext;
 import de.medizininformatikinitiative.cctb.model.cql.CodeSystemDefinition;
 import de.medizininformatikinitiative.cctb.model.cql.Container;
 import de.medizininformatikinitiative.cctb.model.cql.DefaultExpression;
-import de.medizininformatikinitiative.cctb.model.structured_query.Criterion;
+import de.medizininformatikinitiative.cctb.model.structured_query.Group;
 import de.medizininformatikinitiative.cctb.model.structured_query.StructuredQuery;
 import de.medizininformatikinitiative.cctb.model.structured_query.TranslationException;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static de.medizininformatikinitiative.cctb.model.cql.Container.AND;
 import static de.medizininformatikinitiative.cctb.model.cql.Container.AND_NOT;
@@ -58,8 +61,9 @@ public class Translator {
      *                              CQL {@link Container}
      */
     public Container<DefaultExpression> toCql(StructuredQuery structuredQuery) {
-        var inclusionExpr = inclusionExpr(structuredQuery.inclusionCriteria());
-        var exclusionExpr = exclusionExpr(structuredQuery.exclusionCriteria());
+        var allGroupsById = collectGroupsById(structuredQuery);
+        var inclusionExpr = groupsExpr(structuredQuery.inclusionCriteria(), allGroupsById, true);
+        var exclusionExpr = groupsExpr(structuredQuery.exclusionCriteria(), allGroupsById, false);
 
         return exclusionExpr.isEmpty()
                 ? inclusionExpr.moveToPatientContext("InInitialPopulation")
@@ -69,33 +73,35 @@ public class Translator {
     }
 
     /**
-     * Builds the inclusion expression as conjunctive normal form (CNF) of {@code criteria}.
-     *
-     * @param criteria a list of lists of {@link Criterion} representing a CNF
-     * @return a {@link Container} of the boolean inclusion expression together with the used {@link
-     * CodeSystemDefinition CodeSystemDefinitions}
+     * Collects every {@link Group} of {@code structuredQuery}, both inclusion and exclusion side, keyed by
+     * {@link Group#id}, so a group's {@code relativeTimeRestriction} can resolve its {@code anchorRef} regardless
+     * of which side the referenced anchor group lives on.
      */
-    private Container<DefaultExpression> inclusionExpr(List<List<Criterion>> criteria) {
-        return criteria.stream().map(this::orExpr).reduce(Container.empty(), AND);
-    }
-
-    private Container<DefaultExpression> orExpr(List<Criterion> criteria) {
-        return criteria.stream().map(c -> c.toCql(mappingContext)).reduce(Container.empty(), Container.OR);
+    private static Map<String, Group> collectGroupsById(StructuredQuery structuredQuery) {
+        var groupsById = new HashMap<String, Group>();
+        Stream.concat(structuredQuery.inclusionCriteria().stream(), structuredQuery.exclusionCriteria().stream())
+                .filter(group -> group.id() != null)
+                .forEach(group -> groupsById.put(group.id(), group));
+        return groupsById;
     }
 
     /**
-     * Builds the exclusion expression as disjunctive normal form (DNF) of {@code criteria}.
+     * Builds the boolean expression of one side (inclusion or exclusion) of a {@link StructuredQuery} as the
+     * top-level AND of its {@link Group Groups} - the top level is AND-only on both sides (see the CCDL relative
+     * time constraint draft): unchanged from before on the inclusion side, and a deliberate change on the
+     * exclusion side (previously OR-of-AND/DNF at the top level, now AND, matching a group's own criteria - which
+     * still expresses the old DNF shape - carrying the polarity that used to live at the top level).
      *
-     * @param criteria a list of lists of {@link Criterion} representing a DNF
-     * @return a {@link Container} of the boolean exclusion expression together with the used {@link
-     * CodeSystemDefinition CodeSystemDefinitions}
+     * @param groups          the groups of one side of a {@link StructuredQuery}
+     * @param allGroupsById   every group of the whole {@link StructuredQuery}, used to resolve {@code anchorRef}s
+     * @param isInclusionSide {@code true} for {@code inclusionCriteria}, {@code false} for {@code exclusionCriteria}
+     * @return a {@link Container} of the boolean expression together with the used {@link CodeSystemDefinition
+     * CodeSystemDefinitions}
      */
-    private Container<DefaultExpression> exclusionExpr(List<List<Criterion>> criteria) {
-        return criteria.stream().map(this::andExpr).reduce(Container.empty(), Container.OR);
-    }
-
-    private Container<DefaultExpression> andExpr(List<Criterion> criteria) {
-        return criteria.stream().map(c -> c.toCql(mappingContext))
+    private Container<DefaultExpression> groupsExpr(List<Group> groups, Map<String, Group> allGroupsById,
+                                                     boolean isInclusionSide) {
+        return groups.stream()
+                .map(group -> group.toCql(mappingContext, allGroupsById, isInclusionSide))
                 .reduce(Container.empty(), AND);
     }
 }

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/cql/InvocationExpression.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/cql/InvocationExpression.java
@@ -11,6 +11,14 @@ import static java.util.Objects.requireNonNull;
  */
 public record InvocationExpression(Expression<?> expression, String invocation) implements DefaultExpression {
 
+    /**
+     * Higher than every other operator's precedence in this package (the previous highest, {@code
+     * AdditionExpressionTerm}, is 16) - accessor ({@code .member}) binds tighter than any of them, so a lower-
+     * precedence base (e.g. a {@link TypeExpression} cast, as in {@code (x as Period).start}) must be forced to
+     * parenthesize itself rather than printing bare.
+     */
+    public static final int PRECEDENCE = 20;
+
     public InvocationExpression {
         requireNonNull(expression);
         requireNonNull(invocation);
@@ -22,7 +30,8 @@ public record InvocationExpression(Expression<?> expression, String invocation) 
 
     @Override
     public String print(PrintContext printContext) {
-        return "%s.%s".formatted(expression.print(printContext), invocation);
+        return printContext.parenthesize(PRECEDENCE, "%s.%s".formatted(
+                expression.print(printContext.withPrecedence(PRECEDENCE)), invocation));
     }
 
     @Override

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/cql/IsNotNullExpression.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/cql/IsNotNullExpression.java
@@ -1,0 +1,31 @@
+package de.medizininformatikinitiative.cctb.model.cql;
+
+import de.medizininformatikinitiative.cctb.PrintContext;
+
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+public record IsNotNullExpression(Expression<?> expression) implements DefaultExpression {
+
+    public static final int PRECEDENCE = 6;
+
+    public IsNotNullExpression {
+        requireNonNull(expression);
+    }
+
+    public static DefaultExpression of(Expression<?> expression) {
+        return new IsNotNullExpression(expression);
+    }
+
+    @Override
+    public String print(PrintContext printContext) {
+        var operatorPrintContext = printContext.withPrecedence(PRECEDENCE);
+        return printContext.parenthesize(PRECEDENCE, "%s is not null".formatted(expression.print(operatorPrintContext)));
+    }
+
+    @Override
+    public DefaultExpression withIncrementedSuffixes(Map<String, Integer> increments) {
+        return new IsNotNullExpression(expression.withIncrementedSuffixes(increments));
+    }
+}

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/cql/QuantityExpression.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/cql/QuantityExpression.java
@@ -6,22 +6,34 @@ import java.math.BigDecimal;
 
 import static java.util.Objects.requireNonNull;
 
-public record QuantityExpression(BigDecimal value, String unit) implements DefaultExpression {
+public record QuantityExpression(BigDecimal value, String unit, boolean unquoted) implements DefaultExpression {
 
     public QuantityExpression {
         requireNonNull(value);
     }
 
     public static QuantityExpression of(BigDecimal value) {
-        return new QuantityExpression(value, null);
+        return new QuantityExpression(value, null, false);
     }
 
     public static QuantityExpression of(BigDecimal value, String unit) {
-        return new QuantityExpression(value, requireNonNull(unit));
+        return new QuantityExpression(value, requireNonNull(unit), false);
+    }
+
+    /**
+     * Returns a {@code QuantityExpression} that prints {@code unit} as an unquoted CQL calendar duration keyword
+     * (e.g. {@code 3 hours}) instead of a quoted UCUM unit (e.g. {@code 3 'h'}), as used for {@code DateTime +
+     * Quantity} arithmetic.
+     */
+    public static QuantityExpression ofCalendarDuration(BigDecimal value, String unit) {
+        return new QuantityExpression(value, requireNonNull(unit), true);
     }
 
     @Override
     public String print(PrintContext printContext) {
-        return unit == null ? value.toString() : "%s '%s'".formatted(value, unit.replace("'", "\\'"));
+        if (unit == null) {
+            return value.toString();
+        }
+        return unquoted ? "%s %s".formatted(value, unit) : "%s '%s'".formatted(value, unit.replace("'", "\\'"));
     }
 }

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/AbstractCriterion.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/AbstractCriterion.java
@@ -92,7 +92,12 @@ abstract class AbstractCriterion<T extends AbstractCriterion<T>> implements Crit
 
     @Override
     public Container<DefaultExpression> toCql(MappingContext mappingContext) {
-        var expr = fullExpr(mappingContext);
+        return toCql(mappingContext, null);
+    }
+
+    @Override
+    public Container<DefaultExpression> toCql(MappingContext mappingContext, IntervalSelector relativeWindow) {
+        var expr = fullExpr(mappingContext, relativeWindow);
         if (expr.isEmpty()) {
             throw new TranslationException("Failed to expand the concept %s.".formatted(concept));
         }
@@ -110,13 +115,14 @@ abstract class AbstractCriterion<T extends AbstractCriterion<T>> implements Crit
      * Builds an OR-expression with an expression for each concept of the expansion of {@code
      * termCode}.
      */
-    private Container<DefaultExpression> fullExpr(MappingContext mappingContext) {
+    private Container<DefaultExpression> fullExpr(MappingContext mappingContext, IntervalSelector relativeWindow) {
         return mappingContext.expandConcept(concept)
-                .map(termCode -> expr(mappingContext, termCode))
+                .map(termCode -> expr(mappingContext, termCode, relativeWindow))
                 .reduce(Container.empty(), Container.OR);
     }
 
-    private Container<DefaultExpression> expr(MappingContext mappingContext, ContextualTermCode termCode) {
+    private Container<DefaultExpression> expr(MappingContext mappingContext, ContextualTermCode termCode,
+                                              IntervalSelector relativeWindow) {
         var mapping = mappingContext.findMapping(termCode)
                 .orElseThrow(() -> new MappingNotFoundException(termCode));
         switch (mapping.resourceType()) {
@@ -134,7 +140,7 @@ abstract class AbstractCriterion<T extends AbstractCriterion<T>> implements Crit
                             var whereExpr = MembershipExpression.in(referenceExpression, medicationReferencesExpr);
                             return QueryExpression.of(sourceClause, WhereClause.of(whereExpr));
                         });
-                return appendModifier(mappingContext, mapping, query).map(ExistsExpression::of);
+                return appendModifier(mappingContext, mapping, query, relativeWindow).map(ExistsExpression::of);
             }
             default -> {
                 return retrieveExpr(mappingContext, termCode).flatMap(retrieveExpr -> {
@@ -143,10 +149,79 @@ abstract class AbstractCriterion<T extends AbstractCriterion<T>> implements Crit
                     var query = valueExpr(mappingContext, mapping, alias)
                             .map(valueExpr -> QueryExpression.of(sourceClause, WhereClause.of(valueExpr)))
                             .or(() -> QueryExpression.of(sourceClause));
-                    return appendModifier(mappingContext, mapping, query).map(ExistsExpression::of);
+                    return appendModifier(mappingContext, mapping, query, relativeWindow).map(ExistsExpression::of);
                 });
             }
         }
+    }
+
+    /**
+     * Builds a CQL expression evaluating to the list of dates of every matching resource of the expansion of
+     * {@code concept}, reduced to a single point per resource via {@code anchorPoint}.
+     * <p>
+     * Reuses the same retrieve+modifiers query {@link #expr} builds, but projects the date path from {@code
+     * mapping.timeRestrictionMapping()} via a {@link ReturnClause} instead of wrapping in {@link ExistsExpression}.
+     */
+    @Override
+    public Container<DefaultExpression> dateValuesExpr(MappingContext mappingContext, Group.AnchorPoint anchorPoint) {
+        return dateValuesExpr(mappingContext, anchorPoint, null);
+    }
+
+    @Override
+    public Container<DefaultExpression> dateValuesExpr(MappingContext mappingContext, Group.AnchorPoint anchorPoint,
+                                                        IntervalSelector relativeWindow) {
+        return mappingContext.expandConcept(concept)
+                .map(termCode -> dateValueExpr(mappingContext, termCode, anchorPoint, relativeWindow))
+                .reduce(Container.empty(), Container.UNION);
+    }
+
+    private Container<DefaultExpression> dateValueExpr(MappingContext mappingContext, ContextualTermCode termCode,
+                                                        Group.AnchorPoint anchorPoint, IntervalSelector relativeWindow) {
+        var mapping = mappingContext.findMapping(termCode)
+                .orElseThrow(() -> new MappingNotFoundException(termCode));
+        var timeRestrictionMapping = mapping.timeRestrictionMapping()
+                .orElseThrow(() -> new IllegalStateException(
+                        "Missing time restriction in mapping with key %s, required to use it as an anchor."
+                                .formatted(mapping.key())));
+        return retrieveExpr(mappingContext, termCode).flatMap(retrieveExpr -> {
+            var alias = retrieveExpr.alias();
+            var sourceClause = SourceClause.of(AliasedQuerySource.of(retrieveExpr, alias));
+            var invocationExpr = InvocationExpression.of(alias, timeRestrictionMapping.path());
+            var returnClause = ReturnClause.of(dateProjectionExpr(invocationExpr, timeRestrictionMapping, anchorPoint));
+            var query = QueryExpression.of(sourceClause, returnClause);
+            return appendModifier(mappingContext, mapping, Container.of(query), relativeWindow)
+                    .map(WrapperExpression::new);
+        });
+    }
+
+    /**
+     * Casts the date path to a single, comparable value, per possible type of {@code mapping} (structurally the
+     * same per-type dispatch as {@link TimeRestrictionModifier}'s dateExpr/dateTimeExpr/instantExpr, kept
+     * duplicated here since this projects a raw value rather than building a membership check). {@code PERIOD}
+     * needs {@code anchorPoint} ({@code .start}/{@code .end}) before casting. When more than one type is possible
+     * (a polymorphic FHIR choice field), the first non-null projection is used via {@code Coalesce} - every
+     * branch is wrapped in {@code ToDate(...)} so all of them produce the same {@code System.Date} type;
+     * {@code Coalesce} requires its arguments to share one type, and {@code Period.start}/{@code .end} is
+     * {@code FHIR.dateTime}, not {@code Date}, so leaving it unwrapped fails CQL type resolution outright (a real
+     * bug found via an engine-level regression test - Blaze rejects the library with "Could not resolve call to
+     * operator Coalesce with signature (System.Date,FHIR.dateTime)" rather than merely behaving incorrectly).
+     */
+    private static Expression<?> dateProjectionExpr(InvocationExpression invocationExpr,
+                                                     Mapping.TimeRestrictionMapping mapping,
+                                                     Group.AnchorPoint anchorPoint) {
+        var point = anchorPoint == null ? Group.AnchorPoint.START : anchorPoint;
+        List<DefaultExpression> exprs = mapping.types().stream().sorted().<DefaultExpression>map(type -> switch (type) {
+            case DATE -> new WrapperExpression(FunctionInvocation.of("ToDate",
+                    List.of(TypeExpression.of(invocationExpr, "date"))));
+            case DATE_TIME -> new WrapperExpression(FunctionInvocation.of("ToDate",
+                    List.of(TypeExpression.of(invocationExpr, "dateTime"))));
+            case INSTANT -> new WrapperExpression(FunctionInvocation.of("ToDate",
+                    List.of(TypeExpression.of(invocationExpr, "instant"))));
+            case PERIOD -> new WrapperExpression(FunctionInvocation.of("ToDate", List.of(
+                    InvocationExpression.of(TypeExpression.of(invocationExpr, "Period"),
+                            point == Group.AnchorPoint.END ? "end" : "start"))));
+        }).toList();
+        return exprs.size() == 1 ? exprs.get(0) : FunctionInvocation.of("Coalesce", exprs);
     }
 
     private Container<DefaultExpression> refExpr(MappingContext mappingContext, ContextualTermCode termCode) {
@@ -158,7 +233,7 @@ abstract class AbstractCriterion<T extends AbstractCriterion<T>> implements Crit
             var query = valueExpr(mappingContext, mapping, alias)
                     .map(valueExpr -> QueryExpression.of(sourceClause, WhereClause.of(valueExpr)))
                     .or(() -> QueryExpression.of(sourceClause));
-            return appendModifier(mappingContext, mapping, query).map(WrapperExpression::new);
+            return appendModifier(mappingContext, mapping, query, null).map(WrapperExpression::new);
         });
     }
 
@@ -169,10 +244,13 @@ abstract class AbstractCriterion<T extends AbstractCriterion<T>> implements Crit
                                                     IdentifierExpression sourceAlias);
 
     /*
-     * Appends expressions from modifier criteria to the query.
+     * Appends expressions from modifier criteria to the query, including a relative time restriction's already
+     * computed window, if any (see Group#toCql), which intersects (ANDs) with any absolute per-criterion
+     * timeRestriction, matching the "intersect" rule for that interaction.
      */
     private Container<QueryExpression> appendModifier(MappingContext mappingContext, Mapping mapping,
-                                                      Container<QueryExpression> queryContainer) {
+                                                      Container<QueryExpression> queryContainer,
+                                                      IntervalSelector relativeWindow) {
         var termCodeModifier = termCodeModifier(mapping);
         var isRetrievable = mapping.termCodeMapping()
                 .map(v -> FhirModelInfo.isRetrievable(mapping.resourceType(), v.path()))
@@ -188,6 +266,14 @@ abstract class AbstractCriterion<T extends AbstractCriterion<T>> implements Crit
         }
         if (timeRestriction != null) {
             queryContainer = timeRestriction.toModifier(mapping).updateQuery(mappingContext, queryContainer);
+        }
+        if (relativeWindow != null) {
+            var relativeTimeRestrictionMapping = mapping.timeRestrictionMapping()
+                    .orElseThrow(() -> new IllegalStateException(
+                            "Missing time restriction in mapping with key %s, required to apply a relative time restriction."
+                                    .formatted(mapping.key())));
+            queryContainer = RelativeTimeRestrictionModifier.of(relativeTimeRestrictionMapping, relativeWindow)
+                    .updateQuery(mappingContext, queryContainer);
         }
         return queryContainer;
     }

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/Criterion.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/Criterion.java
@@ -12,6 +12,7 @@ import de.medizininformatikinitiative.cctb.model.cql.CodeSystemDefinition;
 import de.medizininformatikinitiative.cctb.model.cql.Container;
 import de.medizininformatikinitiative.cctb.model.cql.DefaultExpression;
 import de.medizininformatikinitiative.cctb.model.cql.Expression;
+import de.medizininformatikinitiative.cctb.model.cql.IntervalSelector;
 
 import java.util.List;
 import java.util.Optional;
@@ -57,6 +58,11 @@ public interface Criterion {
         public TimeRestriction timeRestriction() {
             return null;
         }
+
+        @Override
+        public Container<DefaultExpression> dateValuesExpr(MappingContext mappingContext, Group.AnchorPoint anchorPoint) {
+            throw new UnsupportedOperationException();
+        }
     };
 
     /**
@@ -88,14 +94,24 @@ public interface Criterion {
         public TimeRestriction timeRestriction() {
             return null;
         }
+
+        @Override
+        public Container<DefaultExpression> dateValuesExpr(MappingContext mappingContext, Group.AnchorPoint anchorPoint) {
+            throw new UnsupportedOperationException();
+        }
     };
 
     @JsonCreator
-    static Criterion create(@JsonProperty("context") TermCode context,
+    static Criterion create(@JsonProperty("type") String type,
+                            @JsonProperty("context") TermCode context,
                             @JsonProperty("termCodes") List<TermCode> termCodes,
                             @JsonProperty("valueFilter") ObjectNode valueFilter,
                             @JsonProperty("timeRestriction") TimeRestriction timeRestriction,
                             @JsonProperty("attributeFilters") List<ObjectNode> attributeFilters) {
+        if ("now".equals(type)) {
+            return NowCriterion.INSTANCE;
+        }
+
         var concept = ContextualConcept.of(requireNonNull(context, "missing JSON property: context"),
                 Concept.of(requireNonNull(termCodes, "missing JSON property: termCodes")));
 
@@ -104,8 +120,8 @@ public interface Criterion {
         if (valueFilter == null) {
             criterion = ConceptCriterion.of(concept, timeRestriction);
         } else {
-            var type = valueFilter.get("type").asString();
-            switch (type) {
+            var valueFilterType = valueFilter.get("type").asString();
+            switch (valueFilterType) {
                 case "quantity-comparator" -> {
                     var comparator = Comparator.fromJson(valueFilter.get("comparator").asString());
                     var value = valueFilter.get("value").decimalValue();
@@ -135,7 +151,7 @@ public interface Criterion {
                             StreamSupport.stream(selectedConcepts.spliterator(), false)
                                     .map(TermCode::fromJsonNode).toList(), timeRestriction);
                 }
-                default -> throw new IllegalArgumentException("unknown valueFilter type: " + type);
+                default -> throw new IllegalArgumentException("unknown valueFilter type: " + valueFilterType);
             }
         }
 
@@ -150,7 +166,9 @@ public interface Criterion {
     }
 
     static Criterion fromJsonNode(JsonNode node) {
-        return Criterion.create(TermCode.fromJsonNode(node.get("context")),
+        var typeNode = node.get("type");
+        return Criterion.create(typeNode == null ? null : typeNode.asString(),
+                TermCode.fromJsonNode(node.get("context")),
                 getAndMap(node, "termCodes", termCodesNode -> StreamSupport.stream(termCodesNode.spliterator(), false)
                         .map(TermCode::fromJsonNode).toList()),
                 asObjectNode(node.get("valueFilter")),
@@ -180,7 +198,48 @@ public interface Criterion {
      */
     Container<DefaultExpression> toCql(MappingContext mappingContext);
 
+    /**
+     * Translates this criterion into a CQL expression, additionally restricting it to {@code relativeWindow} -
+     * used when this criterion sits in a {@link Group} with a {@link RelativeTimeRestriction}.
+     * <p>
+     * The default implementation ignores {@code relativeWindow}, appropriate for criteria without an
+     * instance-level date to restrict (e.g. {@link #TRUE}, {@link #FALSE}, {@link NowCriterion}).
+     *
+     * @param mappingContext  contains the mappings needed to create the CQL expression
+     * @param relativeWindow  the computed time window this criterion's matching resources must fall into
+     * @return a {@link Container} of the CQL expression together with its used {@link CodeSystemDefinition
+     * CodeSystemDefinitions}
+     */
+    default Container<DefaultExpression> toCql(MappingContext mappingContext, IntervalSelector relativeWindow) {
+        return toCql(mappingContext);
+    }
+
     Container<DefaultExpression> toReferencesCql(MappingContext mappingContext);
+
+    /**
+     * Returns a CQL expression evaluating to the list of dates of every resource matching this criterion, reduced
+     * to a single point per resource via {@code anchorPoint} - used to resolve the anchor date(s) of a
+     * {@link Group} this criterion sits in.
+     *
+     * @param mappingContext contains the mappings needed to create the CQL expression
+     * @param anchorPoint    which point of a {@code Period}-typed match supplies its date
+     * @return a {@link Container} of the CQL list expression together with its used {@link CodeSystemDefinition
+     * CodeSystemDefinitions}
+     */
+    Container<DefaultExpression> dateValuesExpr(MappingContext mappingContext, Group.AnchorPoint anchorPoint);
+
+    /**
+     * Same as {@link #dateValuesExpr(MappingContext, Group.AnchorPoint)}, additionally restricting the matching
+     * resources to {@code relativeWindow} - used when this criterion sits in a chained anchor group that is
+     * itself a dependent of another anchor.
+     * <p>
+     * The default implementation ignores {@code relativeWindow}, appropriate for criteria without an
+     * instance-level date to restrict.
+     */
+    default Container<DefaultExpression> dateValuesExpr(MappingContext mappingContext, Group.AnchorPoint anchorPoint,
+                                                         IntervalSelector relativeWindow) {
+        return dateValuesExpr(mappingContext, anchorPoint);
+    }
 
     List<AttributeFilter> attributeFilters();
 

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/Group.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/Group.java
@@ -115,22 +115,28 @@ public record Group(String id, List<List<Criterion>> criteria, RelativeTimeRestr
     public Container<DefaultExpression> toCql(MappingContext mappingContext, Map<String, Group> allGroupsById,
                                               boolean isInclusionSide) {
         if (relativeTimeRestriction == null) {
-            return combineCriteria(mappingContext, isInclusionSide, null);
+            return combineCriteria(mappingContext, isInclusionSide, null, null);
         }
         var anchor = allGroupsById.get(relativeTimeRestriction.anchorRef());
-        return computeWindow(mappingContext, allGroupsById, anchor)
-                .flatMap(window -> combineCriteria(mappingContext, isInclusionSide, (IntervalSelector) window));
+        var window = computeWindow(mappingContext, allGroupsById, anchor);
+        return window.interval().flatMap(intervalExpr ->
+                combineCriteria(mappingContext, isInclusionSide, (IntervalSelector) intervalExpr, window.guard()));
     }
 
+    /**
+     * Combines this group's own criteria (level 2/3 AND/OR). When {@code window} is non-null, every leaf
+     * criterion's window-filtered result is AND'd with {@code guard} first - see {@link Window} for why an
+     * explicit guard, rather than the target language's own null-propagation, is required.
+     */
     private Container<DefaultExpression> combineCriteria(MappingContext mappingContext, boolean isInclusionSide,
-                                                          IntervalSelector window) {
+                                                          IntervalSelector window, Container<DefaultExpression> guard) {
         var level2Combiner = isInclusionSide ? Container.AND : Container.OR;
         var level3Combiner = isInclusionSide ? Container.OR : Container.AND;
         return criteria.stream()
                 .map(clause -> clause.stream()
                         .map(criterion -> window == null
                                 ? criterion.toCql(mappingContext)
-                                : criterion.toCql(mappingContext, window))
+                                : Container.AND.apply(guard, criterion.toCql(mappingContext, window)))
                         .reduce(Container.empty(), level3Combiner))
                 .reduce(Container.empty(), level2Combiner);
     }
@@ -162,9 +168,13 @@ public record Group(String id, List<List<Criterion>> criteria, RelativeTimeRestr
             return aggregateClauseDates(mappingContext, null);
         }
         var anchor = allGroupsById.get(relativeTimeRestriction.anchorRef());
-        var windowContainer = computeWindow(mappingContext, allGroupsById, anchor);
-        var earliest = windowContainer.flatMap(w -> aggregateClauseDates(mappingContext, (IntervalSelector) w).earliest());
-        var latest = windowContainer.flatMap(w -> aggregateClauseDates(mappingContext, (IntervalSelector) w).latest());
+        // Known gap, not covered by this fix: chaining doesn't yet apply `window.guard()` to candidate
+        // filtering here - only the final criterion-matching path in combineCriteria does. If the
+        // upstream anchor doesn't resolve, this group's own clause-date resolution can still incorrectly
+        // include out-of-window candidates when it's itself an anchor for something further downstream.
+        var window = computeWindow(mappingContext, allGroupsById, anchor);
+        var earliest = window.interval().flatMap(w -> aggregateClauseDates(mappingContext, (IntervalSelector) w).earliest());
+        var latest = window.interval().flatMap(w -> aggregateClauseDates(mappingContext, (IntervalSelector) w).latest());
         return new AnchorDates(earliest, latest);
     }
 
@@ -234,22 +244,36 @@ public record Group(String id, List<List<Criterion>> criteria, RelativeTimeRestr
     }
 
     /**
-     * Returns a {@link Container} holding the computed window as an {@link IntervalSelector}, upcast to
-     * {@link DefaultExpression} because {@code IntervalSelector} (like every other concrete {@code Expression}
-     * subtype here) implements {@code Expression<DefaultExpression>} rather than {@code Expression<IntervalSelector>}
-     * and so cannot itself be a {@link Container}'s type parameter - callers cast back to {@code IntervalSelector}.
+     * The computed time window ({@code interval}) together with an explicit validity {@code guard} - "did the
+     * anchor actually resolve for this patient" - that {@link #combineCriteria} AND's into every criterion this
+     * window is applied to.
+     * <p>
+     * The guard is required, not optional defensiveness: naive three-valued-logic reasoning suggests a criterion
+     * measured against a window built from an unresolved (null) anchor date should naturally evaluate to false
+     * via ordinary null propagation ({@code Min({})} over an empty candidate list &rarr; null &rarr;
+     * {@code null + Duration} &rarr; null-bounded {@code Interval} &rarr; a {@code where} clause dropping the
+     * row). Confirmed empirically against a real engine (Blaze 0.34) that this does NOT happen - the row is
+     * kept and the criterion incorrectly matches as if the window were unbounded, the worse of the two possible
+     * failure modes. So the guard is built explicitly here from the anchor's own resolved dates, independent of
+     * whatever the target engine's arithmetic/interval-membership null handling actually does.
+     */
+    private record Window(Container<DefaultExpression> interval, Container<DefaultExpression> guard) {}
+
+    /**
+     * Computes this group's {@link Window} against {@code anchor}.
      * <p>
      * {@code windowEnd} (the {@code maxOffset} bound) is built from {@code anchor}'s {@link AnchorDates#earliest},
      * {@code windowStart} (the {@code minOffset} bound) from its {@link AnchorDates#latest} - see the design note
      * on {@link AnchorDates} for why. For a single-clause anchor these are the same, already-named value, so this
      * reduces to exactly the previous, tested behaviour: the anchor date resolved once and referenced by
      * identifier from both bounds instead of embedding a full copy of the (potentially large, concept-expanded)
-     * anchor subquery inline.
+     * anchor subquery inline. The guard checks both {@code earliest} and {@code latest} directly (not the
+     * computed {@code windowStart}/{@code windowEnd}) so it stays correct regardless of how the target engine's
+     * own arithmetic handles a null operand - redundant but harmless when the two are the same value.
      */
-    private Container<DefaultExpression> computeWindow(MappingContext mappingContext, Map<String, Group> allGroupsById,
-                                                        Group anchor) {
+    private Window computeWindow(MappingContext mappingContext, Map<String, Group> allGroupsById, Group anchor) {
         var anchorDates = anchor.resolveAnchorDates(mappingContext, allGroupsById);
-        return anchorDates.latest().flatMap(latestExpr -> anchorDates.earliest().map(earliestExpr -> {
+        var interval = anchorDates.latest().flatMap(latestExpr -> anchorDates.earliest().map(earliestExpr -> {
             Expression<?> windowStart = relativeTimeRestriction.minOffset() == null
                     ? DateTimeExpression.of(TimeRestriction.MIN_AFTER_DATE)
                     : AdditionExpressionTerm.of(latestExpr, offsetQuantity(relativeTimeRestriction.minOffset()));
@@ -258,6 +282,11 @@ public record Group(String id, List<List<Criterion>> criteria, RelativeTimeRestr
                     : AdditionExpressionTerm.of(earliestExpr, offsetQuantity(relativeTimeRestriction.maxOffset()));
             return (DefaultExpression) IntervalSelector.of(windowStart, windowEnd);
         }));
+        var guard = anchorDates.latest().flatMap(latestExpr -> anchorDates.earliest().map(earliestExpr ->
+                earliestExpr.equals(latestExpr)
+                        ? IsNotNullExpression.of(earliestExpr)
+                        : (DefaultExpression) AndExpression.of(IsNotNullExpression.of(earliestExpr), IsNotNullExpression.of(latestExpr))));
+        return new Window(interval, guard);
     }
 
     /**

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/Group.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/Group.java
@@ -1,0 +1,281 @@
+package de.medizininformatikinitiative.cctb.model.structured_query;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import de.medizininformatikinitiative.cctb.model.MappingContext;
+import de.medizininformatikinitiative.cctb.model.cql.*;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A named group of criteria, optionally anchored in time relative to another group (see
+ * {@link RelativeTimeRestriction}).
+ * <p>
+ * {@code criteria} keeps today's existing two-level CNF/DNF shape (AND-of-OR for inclusion, OR-of-AND for
+ * exclusion, see {@link #toCql}), just relocated one level deeper than in the pre-anchor {@code StructuredQuery}
+ * shape - a group's top-level list of criteria-lists is exactly what {@code inclusionCriteria}/
+ * {@code exclusionCriteria} used to be directly.
+ *
+ * @param id                      the group's id, required only if this group is referenced via
+ *                                {@code anchorRef} by another group's {@link RelativeTimeRestriction}
+ * @param criteria                the group's own criteria, in the existing two-level CNF/DNF shape
+ * @param relativeTimeRestriction the time window this group's criteria are restricted to, relative to another
+ *                                group's resolved anchor date, or {@code null} if this group has no relative time
+ *                                restriction
+ * @param anchorOccurrence        which occurrence of this group's own matching resources supplies the anchor date
+ *                                when this group is used as an anchor by another group (required in that case,
+ *                                unless this group's sole criterion is {@code now})
+ * @param anchorPoint             which point of a {@code Period}-typed matching resource supplies the anchor date
+ *                                when this group is used as an anchor by another group; meaningful only then, and
+ *                                only for matches that are actually {@code Period}-typed (defaults to
+ *                                {@link AnchorPoint#START})
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record Group(String id, List<List<Criterion>> criteria, RelativeTimeRestriction relativeTimeRestriction,
+                    AnchorOccurrence anchorOccurrence, AnchorPoint anchorPoint) {
+
+    public Group {
+        criteria = criteria.stream().map(List::copyOf).toList();
+    }
+
+    public static Group of(List<List<Criterion>> criteria) {
+        return create(null, criteria, null, null, null);
+    }
+
+    public static Group of(Criterion... criteria) {
+        return create(null, List.of(List.of(criteria)), null, null, null);
+    }
+
+    public static Group of(String id, List<List<Criterion>> criteria) {
+        return create(id, criteria, null, null, null);
+    }
+
+    public static Group of(String id, Criterion... criteria) {
+        return create(id, List.of(List.of(criteria)), null, null, null);
+    }
+
+    public static Group of(String id, List<List<Criterion>> criteria, AnchorOccurrence anchorOccurrence) {
+        return create(id, criteria, null, anchorOccurrence, null);
+    }
+
+    public static Group of(String id, List<List<Criterion>> criteria, AnchorOccurrence anchorOccurrence,
+                           AnchorPoint anchorPoint) {
+        return create(id, criteria, null, anchorOccurrence, anchorPoint);
+    }
+
+    public static Group of(String id, List<List<Criterion>> criteria, RelativeTimeRestriction relativeTimeRestriction) {
+        return create(id, criteria, relativeTimeRestriction, null, null);
+    }
+
+    public static Group of(String id, List<List<Criterion>> criteria, RelativeTimeRestriction relativeTimeRestriction,
+                           AnchorOccurrence anchorOccurrence) {
+        return create(id, criteria, relativeTimeRestriction, anchorOccurrence, null);
+    }
+
+    @JsonCreator
+    public static Group create(@JsonProperty("id") String id,
+                               @JsonProperty("criteria") List<List<Criterion>> criteria,
+                               @JsonProperty("relativeTimeRestriction") RelativeTimeRestriction relativeTimeRestriction,
+                               @JsonProperty("anchorOccurrence") AnchorOccurrence anchorOccurrence,
+                               @JsonProperty("anchorPoint") AnchorPoint anchorPoint) {
+        if (criteria == null || criteria.isEmpty() || criteria.stream().allMatch(List::isEmpty)) {
+            throw new IllegalArgumentException("empty criteria in group%s"
+                    .formatted(id == null ? "" : " `%s`".formatted(id)));
+        }
+        return new Group(id, criteria, relativeTimeRestriction, anchorOccurrence, anchorPoint);
+    }
+
+    /**
+     * Returns {@code true} iff this group's sole criterion is the {@link NowCriterion now} criterion, which has
+     * exactly one occurrence by definition and therefore needs no {@link #anchorOccurrence} even when used as an
+     * anchor.
+     */
+    boolean isNowGroup() {
+        return criteria.size() == 1 && criteria.get(0).size() == 1 && criteria.get(0).get(0) instanceof NowCriterion;
+    }
+
+    /**
+     * Translates this group into a CQL expression.
+     *
+     * @param mappingContext  contains the mappings needed to create the CQL expression
+     * @param allGroupsById   every group of the whole {@link StructuredQuery} (both inclusion and exclusion side),
+     *                        keyed by {@link #id}, used to resolve {@code anchorRef}s
+     * @param isInclusionSide {@code true} if this group sits in {@code inclusionCriteria} (AND-of-OR), {@code
+     *                        false} if it sits in {@code exclusionCriteria} (OR-of-AND)
+     * @return a {@link Container} of the CQL expression together with its used {@link CodeSystemDefinition
+     * CodeSystemDefinitions}
+     */
+    public Container<DefaultExpression> toCql(MappingContext mappingContext, Map<String, Group> allGroupsById,
+                                              boolean isInclusionSide) {
+        if (relativeTimeRestriction == null) {
+            return combineCriteria(mappingContext, isInclusionSide, null);
+        }
+        var anchor = allGroupsById.get(relativeTimeRestriction.anchorRef());
+        return computeWindow(mappingContext, allGroupsById, anchor)
+                .flatMap(window -> combineCriteria(mappingContext, isInclusionSide, (IntervalSelector) window));
+    }
+
+    private Container<DefaultExpression> combineCriteria(MappingContext mappingContext, boolean isInclusionSide,
+                                                          IntervalSelector window) {
+        var level2Combiner = isInclusionSide ? Container.AND : Container.OR;
+        var level3Combiner = isInclusionSide ? Container.OR : Container.AND;
+        return criteria.stream()
+                .map(clause -> clause.stream()
+                        .map(criterion -> window == null
+                                ? criterion.toCql(mappingContext)
+                                : criterion.toCql(mappingContext, window))
+                        .reduce(Container.empty(), level3Combiner))
+                .reduce(Container.empty(), level2Combiner);
+    }
+
+    /**
+     * This group's own resolved anchor date(s), as used by a dependent group's {@link RelativeTimeRestriction}:
+     * {@code earliest} is the earliest date across this group's AND'd clauses, {@code latest} the latest. For a
+     * single-clause group (today's only previously-supported case) both are the identical value.
+     * <p>
+     * The two are deliberately kept separate rather than collapsed to one anchor point, and consumed
+     * asymmetrically by {@link #computeWindow}: a dependent's {@code maxOffset} bound is computed from
+     * {@code earliest}, its {@code minOffset} bound from {@code latest}. Why: this group (all clauses required)
+     * is only true once its <em>last</em> clause is satisfied, so nothing can be "at/after" it before that moment
+     * - the latest clause is the binding constraint for the lower bound. But something is "within {@code
+     * maxOffset} after" this group only if it is within {@code maxOffset} of <em>every</em> clause, and the
+     * earliest clause produces the tightest (most binding) ceiling for that. Collapsing to a single point (either
+     * the earliest or the latest) always gets one of the two bounds wrong.
+     */
+    private record AnchorDates(Container<DefaultExpression> earliest, Container<DefaultExpression> latest) {}
+
+    /**
+     * Resolves {@link AnchorDates} for this group. If this group is itself a dependent of another anchor
+     * (chaining), its own {@link #relativeTimeRestriction} is resolved and applied first, so its candidate
+     * resources are already window-filtered before aggregation - the {@code anchorRef} graph is validated
+     * acyclic by {@link StructuredQuery}, so this recursion terminates.
+     */
+    private AnchorDates resolveAnchorDates(MappingContext mappingContext, Map<String, Group> allGroupsById) {
+        if (relativeTimeRestriction == null) {
+            return aggregateClauseDates(mappingContext, null);
+        }
+        var anchor = allGroupsById.get(relativeTimeRestriction.anchorRef());
+        var windowContainer = computeWindow(mappingContext, allGroupsById, anchor);
+        var earliest = windowContainer.flatMap(w -> aggregateClauseDates(mappingContext, (IntervalSelector) w).earliest());
+        var latest = windowContainer.flatMap(w -> aggregateClauseDates(mappingContext, (IntervalSelector) w).latest());
+        return new AnchorDates(earliest, latest);
+    }
+
+    /**
+     * Builds {@link AnchorDates} from this group's own clauses. A single clause resolves directly (via
+     * {@link #resolveClauseDate}) and is named once, becoming both {@code earliest} and {@code latest} - exactly
+     * today's behaviour for the previously-only-supported single-clause case. Multiple (AND'd) clauses each
+     * resolve independently, get combined into one named CQL list (see {@link #clauseDatesListExpr}), and
+     * {@code earliest}/{@code latest} become {@code Min}/{@code Max} over that shared list.
+     */
+    private AnchorDates aggregateClauseDates(MappingContext mappingContext, IntervalSelector window) {
+        if (criteria.size() == 1) {
+            var named = resolveClauseDate(mappingContext, criteria.get(0), window)
+                    .moveToPatientContext("AnchorDate_" + id);
+            return new AnchorDates(named, named);
+        }
+        var namedList = clauseDatesListExpr(mappingContext, window).moveToPatientContext("AnchorDate_" + id);
+        var earliest = namedList.map(listExpr -> (DefaultExpression) new WrapperExpression(
+                FunctionInvocation.of("Min", List.of(listExpr))));
+        var latest = namedList.map(listExpr -> (DefaultExpression) new WrapperExpression(
+                FunctionInvocation.of("Max", List.of(listExpr))));
+        return new AnchorDates(earliest, latest);
+    }
+
+    /**
+     * Resolves one clause's own date: gathers every resource matching its criteria, reduces each to a single
+     * {@link AnchorPoint point}, and collapses them to one timestamp via {@code Min} ({@link
+     * AnchorOccurrence#FIRST}) or {@code Max} ({@link AnchorOccurrence#LAST}).
+     */
+    private Container<DefaultExpression> resolveClauseDate(MappingContext mappingContext, List<Criterion> clause,
+                                                            IntervalSelector window) {
+        var point = anchorPoint == null ? AnchorPoint.START : anchorPoint;
+        Container<DefaultExpression> datesExpr = clause.stream()
+                .map(criterion -> window == null
+                        ? criterion.dateValuesExpr(mappingContext, point)
+                        : criterion.dateValuesExpr(mappingContext, point, window))
+                .reduce(Container.empty(), Container.UNION);
+        var occurrence = anchorOccurrence == null ? AnchorOccurrence.FIRST : anchorOccurrence;
+        var aggregateFunction = occurrence == AnchorOccurrence.LAST ? "Max" : "Min";
+        return datesExpr.map(listExpr -> (DefaultExpression) new WrapperExpression(
+                FunctionInvocation.of(aggregateFunction, List.of(listExpr))));
+    }
+
+    /**
+     * Combines every clause's own resolved date ({@link #resolveClauseDate}) into one CQL list literal (e.g.
+     * {@code { clause1Date, clause2Date }}), so {@link #aggregateClauseDates} can derive both {@code Min} and
+     * {@code Max} across clauses from the same shared, named value. Built via sequential {@link
+     * Container#flatMap} rather than the static combiners ({@code Container.AND}/{@code UNION}) deliberately: at
+     * this point none of the per-clause containers carry any named definitions yet, so there is no risk of the
+     * name-collision-avoidance renaming those static combiners apply when merging independently-built containers.
+     */
+    private Container<DefaultExpression> clauseDatesListExpr(MappingContext mappingContext, IntervalSelector window) {
+        var perClause = criteria.stream().map(clause -> resolveClauseDate(mappingContext, clause, window)).toList();
+        var collected = new ArrayList<DefaultExpression>();
+        Container<DefaultExpression> acc = perClause.get(0).map(expr -> {
+            collected.add(expr);
+            return expr;
+        });
+        for (var i = 1; i < perClause.size(); i++) {
+            var next = perClause.get(i);
+            acc = acc.flatMap(ignored -> next.map(expr -> {
+                collected.add(expr);
+                return expr;
+            }));
+        }
+        return acc.map(ignored -> (DefaultExpression) new WrapperExpression(ListSelector.of(List.copyOf(collected))));
+    }
+
+    /**
+     * Returns a {@link Container} holding the computed window as an {@link IntervalSelector}, upcast to
+     * {@link DefaultExpression} because {@code IntervalSelector} (like every other concrete {@code Expression}
+     * subtype here) implements {@code Expression<DefaultExpression>} rather than {@code Expression<IntervalSelector>}
+     * and so cannot itself be a {@link Container}'s type parameter - callers cast back to {@code IntervalSelector}.
+     * <p>
+     * {@code windowEnd} (the {@code maxOffset} bound) is built from {@code anchor}'s {@link AnchorDates#earliest},
+     * {@code windowStart} (the {@code minOffset} bound) from its {@link AnchorDates#latest} - see the design note
+     * on {@link AnchorDates} for why. For a single-clause anchor these are the same, already-named value, so this
+     * reduces to exactly the previous, tested behaviour: the anchor date resolved once and referenced by
+     * identifier from both bounds instead of embedding a full copy of the (potentially large, concept-expanded)
+     * anchor subquery inline.
+     */
+    private Container<DefaultExpression> computeWindow(MappingContext mappingContext, Map<String, Group> allGroupsById,
+                                                        Group anchor) {
+        var anchorDates = anchor.resolveAnchorDates(mappingContext, allGroupsById);
+        return anchorDates.latest().flatMap(latestExpr -> anchorDates.earliest().map(earliestExpr -> {
+            Expression<?> windowStart = relativeTimeRestriction.minOffset() == null
+                    ? DateTimeExpression.of(TimeRestriction.MIN_AFTER_DATE)
+                    : AdditionExpressionTerm.of(latestExpr, offsetQuantity(relativeTimeRestriction.minOffset()));
+            Expression<?> windowEnd = relativeTimeRestriction.maxOffset() == null
+                    ? DateTimeExpression.of(TimeRestriction.MAX_BEFORE_DATE)
+                    : AdditionExpressionTerm.of(earliestExpr, offsetQuantity(relativeTimeRestriction.maxOffset()));
+            return (DefaultExpression) IntervalSelector.of(windowStart, windowEnd);
+        }));
+    }
+
+    /**
+     * Normalizes an offset {@link Duration} to whole hours and prints it as an unquoted CQL calendar duration
+     * keyword (e.g. {@code 3 hours}), sidestepping calendar-day/DST ambiguity in {@code DateTime + Quantity}
+     * arithmetic. Sub-day (hour) precision is enough for the offsets this feature is meant for (see plan).
+     */
+    private static QuantityExpression offsetQuantity(Duration offset) {
+        return QuantityExpression.ofCalendarDuration(BigDecimal.valueOf(offset.toHours()), "hours");
+    }
+
+    public enum AnchorOccurrence {
+        @JsonProperty("first") FIRST,
+        @JsonProperty("last") LAST
+    }
+
+    public enum AnchorPoint {
+        @JsonProperty("start") START,
+        @JsonProperty("end") END
+    }
+}

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/NowCriterion.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/NowCriterion.java
@@ -1,0 +1,62 @@
+package de.medizininformatikinitiative.cctb.model.structured_query;
+
+import de.medizininformatikinitiative.cctb.model.MappingContext;
+import de.medizininformatikinitiative.cctb.model.cql.Container;
+import de.medizininformatikinitiative.cctb.model.cql.DefaultExpression;
+import de.medizininformatikinitiative.cctb.model.cql.Expression;
+import de.medizininformatikinitiative.cctb.model.cql.FunctionInvocation;
+import de.medizininformatikinitiative.cctb.model.cql.ListSelector;
+import de.medizininformatikinitiative.cctb.model.cql.WrapperExpression;
+
+import java.util.List;
+
+/**
+ * The reserved {@code now} criterion (JSON {@code {"type": "now"}}), used to express time constraints relative to
+ * "today / the evaluation date" via the same anchor mechanism used for clinical events.
+ * <p>
+ * It always resolves to the evaluation timestamp and trivially matches every patient, exactly like
+ * {@link Criterion#TRUE}; a group containing only a {@code now} criterion exists purely to be referenced via
+ * {@code anchorRef}.
+ */
+public final class NowCriterion implements Criterion {
+
+    public static final NowCriterion INSTANCE = new NowCriterion();
+
+    private NowCriterion() {
+    }
+
+    public static NowCriterion of() {
+        return INSTANCE;
+    }
+
+    @Override
+    public ContextualConcept getConcept() {
+        return null;
+    }
+
+    @Override
+    public Container<DefaultExpression> toCql(MappingContext mappingContext) {
+        return Container.of(Expression.TRUE).moveToPatientContext("Criterion");
+    }
+
+    @Override
+    public Container<DefaultExpression> toReferencesCql(MappingContext mappingContext) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<AttributeFilter> attributeFilters() {
+        return List.of();
+    }
+
+    @Override
+    public TimeRestriction timeRestriction() {
+        return null;
+    }
+
+    @Override
+    public Container<DefaultExpression> dateValuesExpr(MappingContext mappingContext, Group.AnchorPoint anchorPoint) {
+        var now = new WrapperExpression(FunctionInvocation.of("Now", List.of()));
+        return Container.of((DefaultExpression) new WrapperExpression(ListSelector.of(List.of(now))));
+    }
+}

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/RelativeTimeRestriction.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/RelativeTimeRestriction.java
@@ -1,0 +1,51 @@
+package de.medizininformatikinitiative.cctb.model.structured_query;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.time.Duration;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A time window relative to another {@link Group group's} resolved anchor date.
+ * <p>
+ * {@code minOffset}/{@code maxOffset} are signed offsets from the anchor date (negative = before the anchor,
+ * positive = after), mirroring the ISO 8601 signed-duration convention {@link Duration#parse} already accepts.
+ * At least one of {@code minOffset}/{@code maxOffset} is required, mirroring {@link TimeRestriction}'s existing
+ * {@code afterDate}/{@code beforeDate} rule.
+ *
+ * @param anchorRef  the {@code id} of the {@link Group} this restriction is relative to
+ * @param minOffset  the offset from the anchor date defining the (inclusive) start of the window, or {@code null}
+ *                   for an unbounded start
+ * @param maxOffset  the offset from the anchor date defining the (inclusive) end of the window, or {@code null}
+ *                   for an unbounded end
+ */
+public record RelativeTimeRestriction(String anchorRef, Duration minOffset, Duration maxOffset) {
+
+    public RelativeTimeRestriction {
+        requireNonNull(anchorRef);
+        if (minOffset == null && maxOffset == null) {
+            throw new IllegalArgumentException(
+                    "Invalid relative time restriction: at least one of minOffset/maxOffset is required.");
+        }
+        if (minOffset != null && maxOffset != null && minOffset.compareTo(maxOffset) > 0) {
+            throw new IllegalArgumentException(
+                    "Invalid relative time restriction: minOffset `%s` is after maxOffset `%s` but should not be."
+                            .formatted(minOffset, maxOffset));
+        }
+    }
+
+    public static RelativeTimeRestriction of(String anchorRef, Duration minOffset, Duration maxOffset) {
+        return new RelativeTimeRestriction(anchorRef, minOffset, maxOffset);
+    }
+
+    @JsonCreator
+    public static RelativeTimeRestriction create(@JsonProperty("anchorRef") String anchorRef,
+                                                 @JsonProperty("minOffset") String minOffset,
+                                                 @JsonProperty("maxOffset") String maxOffset) {
+        return new RelativeTimeRestriction(requireNonNull(anchorRef, "missing JSON property: anchorRef"),
+                minOffset == null ? null : Duration.parse(minOffset),
+                maxOffset == null ? null : Duration.parse(maxOffset));
+    }
+}

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/RelativeTimeRestrictionModifier.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/RelativeTimeRestrictionModifier.java
@@ -1,0 +1,32 @@
+package de.medizininformatikinitiative.cctb.model.structured_query;
+
+import de.medizininformatikinitiative.cctb.model.Mapping;
+import de.medizininformatikinitiative.cctb.model.MappingContext;
+import de.medizininformatikinitiative.cctb.model.cql.*;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Applies an already-computed {@link IntervalSelector} (an anchor date plus/minus an offset, see
+ * {@link Group#toCql}) as a per-criterion time restriction, reusing {@link TimeRestrictionModifier#distribute} -
+ * the same per-type (DATE/DATE_TIME/INSTANT/PERIOD) distribution mechanism the literal, absolute
+ * {@link TimeRestrictionModifier} uses, just fed a computed interval instead of a literal one.
+ */
+public record RelativeTimeRestrictionModifier(Mapping.TimeRestrictionMapping mapping,
+                                               IntervalSelector intervalSelector) implements SimpleModifier {
+
+    public RelativeTimeRestrictionModifier {
+        requireNonNull(mapping);
+        requireNonNull(intervalSelector);
+    }
+
+    public static RelativeTimeRestrictionModifier of(Mapping.TimeRestrictionMapping mapping, IntervalSelector intervalSelector) {
+        return new RelativeTimeRestrictionModifier(mapping, intervalSelector);
+    }
+
+    @Override
+    public Container<DefaultExpression> expression(MappingContext mappingContext, IdentifierExpression sourceAlias) {
+        var invocationExpr = InvocationExpression.of(sourceAlias, mapping.path());
+        return Container.of(TimeRestrictionModifier.distribute(mapping, invocationExpr, type -> intervalSelector));
+    }
+}

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/StructuredQuery.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/StructuredQuery.java
@@ -4,30 +4,110 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 /**
  * @author Alexander Kiel
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record StructuredQuery(List<List<Criterion>> inclusionCriteria, List<List<Criterion>> exclusionCriteria) {
+public record StructuredQuery(List<Group> inclusionCriteria, List<Group> exclusionCriteria) {
 
     public StructuredQuery {
-        inclusionCriteria = inclusionCriteria.stream().map(List::copyOf).toList();
-        exclusionCriteria = exclusionCriteria.stream().map(List::copyOf).toList();
+        inclusionCriteria = List.copyOf(inclusionCriteria);
+        exclusionCriteria = List.copyOf(exclusionCriteria);
     }
 
-    public static StructuredQuery of(List<List<Criterion>> inclusionCriteria) {
-        return new StructuredQuery(inclusionCriteria, List.of(List.of()));
+    public static StructuredQuery of(List<Group> inclusionCriteria) {
+        return of(inclusionCriteria, List.of());
     }
 
     @JsonCreator
-    public static StructuredQuery of(@JsonProperty("inclusionCriteria") List<List<Criterion>> inclusionCriteria,
-                                     @JsonProperty("exclusionCriteria") List<List<Criterion>> exclusionCriteria) {
-        if (inclusionCriteria.isEmpty() || inclusionCriteria.stream().allMatch(List::isEmpty)) {
+    public static StructuredQuery of(@JsonProperty("inclusionCriteria") List<Group> inclusionCriteria,
+                                     @JsonProperty("exclusionCriteria") List<Group> exclusionCriteria) {
+        if (inclusionCriteria == null || inclusionCriteria.isEmpty()) {
             throw new IllegalArgumentException("empty inclusion criteria");
         }
-        return new StructuredQuery(inclusionCriteria,
-                exclusionCriteria == null ? List.of(List.of()) : exclusionCriteria);
+        var resolvedExclusionCriteria = exclusionCriteria == null ? List.<Group>of() : exclusionCriteria;
+        validate(inclusionCriteria, resolvedExclusionCriteria);
+        return new StructuredQuery(inclusionCriteria, resolvedExclusionCriteria);
+    }
+
+    /**
+     * Validates cross-group invariants that a single {@link Group} cannot check on its own: unique ids across the
+     * whole document, every {@code anchorRef} resolving to a known id, the {@code anchorRef} graph being acyclic,
+     * and every group used as an anchor having {@code anchorOccurrence} set (unless its sole criterion is
+     * {@code now}, which has exactly one occurrence by definition).
+     * <p>
+     * An anchor group may have multiple (AND'd) clauses - see {@link Group}'s {@code AnchorDates} design note for
+     * how a dependent's window is computed asymmetrically across them (earliest clause bounds {@code maxOffset},
+     * latest bounds {@code minOffset}) rather than requiring a single unambiguous witness resource.
+     * <p>
+     * A {@link RelativeTimeRestriction} always targets exactly one {@code anchorRef} (it is a single
+     * {@code String}), so "multiple anchors per dependent group" is unsupported by construction and needs no
+     * explicit check here.
+     */
+    private static void validate(List<Group> inclusionCriteria, List<Group> exclusionCriteria) {
+        var allGroups = Stream.concat(inclusionCriteria.stream(), exclusionCriteria.stream()).toList();
+
+        var seenIds = new HashSet<String>();
+        for (var group : allGroups) {
+            if (group.id() != null && !seenIds.add(group.id())) {
+                throw new IllegalArgumentException("Duplicate group id `%s`.".formatted(group.id()));
+            }
+        }
+
+        var groupsById = new HashMap<String, Group>();
+        for (var group : allGroups) {
+            if (group.id() != null) {
+                groupsById.put(group.id(), group);
+            }
+        }
+
+        var referencedAsAnchor = new HashSet<String>();
+        for (var group : allGroups) {
+            var relativeTimeRestriction = group.relativeTimeRestriction();
+            if (relativeTimeRestriction != null) {
+                var anchorRef = relativeTimeRestriction.anchorRef();
+                var anchor = groupsById.get(anchorRef);
+                if (anchor == null) {
+                    throw new IllegalArgumentException("Unknown anchorRef `%s`%s.".formatted(anchorRef,
+                            group.id() == null ? "" : " in group `%s`".formatted(group.id())));
+                }
+                referencedAsAnchor.add(anchorRef);
+            }
+        }
+
+        for (var anchorId : referencedAsAnchor) {
+            var anchor = groupsById.get(anchorId);
+            if (anchor.anchorOccurrence() == null && !anchor.isNowGroup()) {
+                throw new IllegalArgumentException(
+                        "Group `%s` is used as an anchor and therefore requires `anchorOccurrence` to be set."
+                                .formatted(anchorId));
+            }
+        }
+
+        for (var group : allGroups) {
+            if (group.id() != null) {
+                detectCycle(group.id(), groupsById, new LinkedHashSet<>());
+            }
+        }
+    }
+
+    private static void detectCycle(String groupId, Map<String, Group> groupsById, LinkedHashSet<String> path) {
+        if (!path.add(groupId)) {
+            throw new IllegalArgumentException(
+                    "Cyclic anchorRef graph detected: %s -> %s.".formatted(String.join(" -> ", path), groupId));
+        }
+        var group = groupsById.get(groupId);
+        var relativeTimeRestriction = group == null ? null : group.relativeTimeRestriction();
+        if (relativeTimeRestriction != null) {
+            detectCycle(relativeTimeRestriction.anchorRef(), groupsById, path);
+        }
+        path.remove(groupId);
     }
 }

--- a/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/TimeRestrictionModifier.java
+++ b/cql/src/main/java/de/medizininformatikinitiative/cctb/model/structured_query/TimeRestrictionModifier.java
@@ -6,6 +6,7 @@ import de.medizininformatikinitiative.cctb.model.cql.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.function.Function;
 
 import static java.util.Objects.requireNonNull;
 
@@ -40,16 +41,38 @@ public record TimeRestrictionModifier(Mapping.TimeRestrictionMapping mapping, Lo
         return MembershipExpression.in(toDateFunction, intervalSelector);
     }
 
+    /**
+     * Builds the per-type (DATE/DATE_TIME/INSTANT/PERIOD) membership/overlap check, OR'd across every type
+     * {@code mapping} says the target path can have, distributing a window over all of a field's possible FHIR
+     * types.
+     * <p>
+     * Takes a function from type to {@link IntervalSelector} rather than a single shared interval because the
+     * literal, absolute restriction ({@link #expression(MappingContext, IdentifierExpression)}) needs
+     * differently-typed interval bounds for {@code DATE} (a date-only literal) than for
+     * {@code DATE_TIME}/{@code INSTANT}/{@code PERIOD} (a dateTime literal). {@link RelativeTimeRestrictionModifier}
+     * (the other caller) always distributes the same computed, dateTime-valued interval regardless of type.
+     * <p>
+     * This is a mechanical extraction of the switch that used to live directly in {@link #expression} - behavior
+     * for the literal, absolute restriction path is unchanged.
+     */
+    static DefaultExpression distribute(Mapping.TimeRestrictionMapping mapping, InvocationExpression invocationExpr,
+                                        Function<Mapping.TimeRestrictionMapping.Type, IntervalSelector> intervalSelectorForType) {
+        //noinspection OptionalGetWithoutIsPresent
+        return mapping.types().stream().sorted().map(type -> switch (type) {
+            case DATE -> dateExpr(invocationExpr, intervalSelectorForType.apply(type));
+            case DATE_TIME -> dateTimeExpr(invocationExpr, intervalSelectorForType.apply(type));
+            case INSTANT -> instantExpr(invocationExpr, intervalSelectorForType.apply(type));
+            case PERIOD -> OverlapsIntervalOperatorPhrase.of(invocationExpr, intervalSelectorForType.apply(type));
+        }).reduce(OrExpression::of).get();
+    }
+
     @Override
     public Container<DefaultExpression> expression(MappingContext mappingContext, IdentifierExpression sourceAlias) {
         var invocationExpr = InvocationExpression.of(sourceAlias, mapping.path());
+        var dateInterval = IntervalSelector.of(DateExpression.of(afterDate), DateExpression.of(beforeDate));
+        var dateTimeInterval = IntervalSelector.of(DateTimeExpression.of(afterDate), DateTimeExpression.of(beforeDate));
 
-        //noinspection OptionalGetWithoutIsPresent
-        return Container.of(mapping.types().stream().sorted().map(type -> switch (type) {
-            case DATE -> dateExpr(invocationExpr, IntervalSelector.of(DateExpression.of(afterDate), DateExpression.of(beforeDate)));
-            case DATE_TIME -> dateTimeExpr(invocationExpr, IntervalSelector.of(DateTimeExpression.of(afterDate), DateTimeExpression.of(beforeDate)));
-            case INSTANT -> instantExpr(invocationExpr, IntervalSelector.of(DateTimeExpression.of(afterDate), DateTimeExpression.of(beforeDate)));
-            case PERIOD -> OverlapsIntervalOperatorPhrase.of(invocationExpr, IntervalSelector.of(DateTimeExpression.of(afterDate), DateTimeExpression.of(beforeDate)));
-        }).reduce(OrExpression::of).get());
+        return Container.of(distribute(mapping, invocationExpr,
+                type -> type == Mapping.TimeRestrictionMapping.Type.DATE ? dateInterval : dateTimeInterval));
     }
 }

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/EvaluationIT.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/EvaluationIT.java
@@ -8,9 +8,12 @@ import de.medizininformatikinitiative.cctb.model.Mapping;
 import de.medizininformatikinitiative.cctb.model.MappingContext;
 import tools.jackson.databind.ObjectMapper;
 import de.medizininformatikinitiative.cctb.model.common.TermCode;
+import de.medizininformatikinitiative.cctb.model.structured_query.ConceptCriterion;
 import de.medizininformatikinitiative.cctb.model.structured_query.ContextualConcept;
 import de.medizininformatikinitiative.cctb.model.structured_query.ContextualTermCode;
+import de.medizininformatikinitiative.cctb.model.structured_query.Group;
 import de.medizininformatikinitiative.cctb.model.structured_query.NumericCriterion;
+import de.medizininformatikinitiative.cctb.model.structured_query.RelativeTimeRestriction;
 import de.medizininformatikinitiative.cctb.model.structured_query.StructuredQuery;
 import org.hl7.fhir.instance.model.api.IBaseResource;
 import org.hl7.fhir.r4.model.*;
@@ -26,11 +29,14 @@ import org.testcontainers.utility.DockerImageName;
 import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 import static de.medizininformatikinitiative.cctb.Util.createTreeWithoutChildren;
+import static de.medizininformatikinitiative.cctb.model.Mapping.TimeRestrictionMapping.Type.DATE_TIME;
+import static de.medizininformatikinitiative.cctb.model.Mapping.TimeRestrictionMapping.Type.PERIOD;
 import static de.medizininformatikinitiative.cctb.model.common.Comparator.LESS_THAN;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -48,6 +54,10 @@ public class EvaluationIT {
             "Blood pressure panel with all children optional"));
     static final TermCode DIASTOLIC_BLOOD_PRESSURE = TermCode.of("http://loinc.org", "8462-4",
             "Diastolic blood pressure");
+    static final ContextualTermCode DEMENTIA_DIAGNOSIS = ContextualTermCode.of(CONTEXT,
+            TermCode.of("http://fhir.de/CodeSystem/dimdi/icd-10-gm", "F00", "Demenz bei Alzheimer-Krankheit"));
+    static final ContextualTermCode CRP = ContextualTermCode.of(CONTEXT,
+            TermCode.of("http://loinc.org", "1988-5", "C-reaktives Protein"));
     static final Map<String, String> CODE_SYSTEM_ALIASES = Map.of("http://loinc.org", "loinc");
 
     @Container
@@ -104,7 +114,7 @@ public class EvaluationIT {
         var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
         var translator = Translator.of(mappingContext);
         var criterion = NumericCriterion.of(ContextualConcept.of(BLOOD_PRESSURE), LESS_THAN, BigDecimal.valueOf(80), "mm[Hg]");
-        var structuredQuery = StructuredQuery.of(List.of(List.of(criterion)));
+        var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(criterion)))));
         var cql = translator.toCql(structuredQuery).print();
         var libraryUri = "urn:uuid" + UUID.randomUUID();
         var library = appendCql(parseResource(Library.class, slurp("Library.json")).setUrl(libraryUri), cql);
@@ -166,37 +176,41 @@ public class EvaluationIT {
                   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
                   "display": "",
                   "inclusionCriteria": [
-                    [
-                      {
-                        "context": {
-                          "system": "context",
-                          "code": "context",
-                          "display": "context"
-                        },
-                        "termCodes": [
+                    {
+                      "criteria": [
+                        [
                           {
-                            "system": "http://loinc.org",
-                            "code": "85354-9",
-                            "display": "Blood pressure panel with all children optional"
-                          }
-                        ],
-                        "attributeFilters": [
-                          {
-                            "attributeCode": {
-                              "system": "http://loinc.org",
-                              "code": "8462-4",
-                              "display": "Diastolic blood pressure"
+                            "context": {
+                              "system": "context",
+                              "code": "context",
+                              "display": "context"
                             },
-                            "type": "quantity-comparator",
-                            "comparator": "lt",
-                            "value": 80,
-                            "unit": {
-                              "code": "mm[Hg]"
-                            }
+                            "termCodes": [
+                              {
+                                "system": "http://loinc.org",
+                                "code": "85354-9",
+                                "display": "Blood pressure panel with all children optional"
+                              }
+                            ],
+                            "attributeFilters": [
+                              {
+                                "attributeCode": {
+                                  "system": "http://loinc.org",
+                                  "code": "8462-4",
+                                  "display": "Diastolic blood pressure"
+                                },
+                                "type": "quantity-comparator",
+                                "comparator": "lt",
+                                "value": 80,
+                                "unit": {
+                                  "code": "mm[Hg]"
+                                }
+                              }
+                            ]
                           }
                         ]
-                      }
-                    ]
+                      ]
+                    }
                   ]
                 }
                 """);
@@ -220,6 +234,171 @@ public class EvaluationIT {
                 .execute();
 
         assertEquals(1, report.getGroupFirstRep().getPopulationFirstRep().getCount());
+    }
+
+    /**
+     * Proves the relative-time-restriction / anchor feature against a real CQL engine, including the boundary
+     * between "inside" and "outside" the computed window - something print-string unit tests alone can't confirm.
+     * <p>
+     * Two patients each have the same diagnosis (the anchor, dated 2024-01-10). One has a CRP measurement 2 days
+     * before it (inside the "up to 3 days before, up to the diagnosis" window); the other has one 9 days before
+     * (outside it). Only the first should be counted.
+     */
+    @Test
+    public void evaluateRelativeTimeRestriction() throws Exception {
+        var diagnosisMapping = Mapping.of(DEMENTIA_DIAGNOSIS, "Condition", null, List.of(), List.of(),
+                Mapping.TimeRestrictionMapping.of("onset", Mapping.TimeRestrictionMapping.Type.DATE_TIME));
+        var crpMapping = Mapping.of(CRP, "Observation", null, List.of(), List.of(),
+                Mapping.TimeRestrictionMapping.of("effective", Mapping.TimeRestrictionMapping.Type.DATE_TIME));
+        var mappings = Map.of(DEMENTIA_DIAGNOSIS, diagnosisMapping, CRP, crpMapping);
+        var mappingContext = MappingContext.of(mappings, null, CODE_SYSTEM_ALIASES);
+        var translator = Translator.of(mappingContext);
+
+        var anchorGroup = Group.of("diagnosis", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(DEMENTIA_DIAGNOSIS)))),
+                Group.AnchorOccurrence.FIRST);
+        var dependentGroup = Group.of(null, List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                RelativeTimeRestriction.of("diagnosis", Duration.parse("-P3D"), Duration.ZERO));
+        var structuredQuery = StructuredQuery.of(List.of(anchorGroup, dependentGroup));
+        var cql = translator.toCql(structuredQuery).print();
+
+        var bundle = new Bundle().setType(TRANSACTION);
+        addPut(bundle, "Patient", "within-window", patient("within-window"));
+        addPut(bundle, "Condition", "within-window-diagnosis",
+                condition("within-window-diagnosis", "within-window", DEMENTIA_DIAGNOSIS, "2024-01-10"));
+        addPut(bundle, "Observation", "within-window-crp",
+                observation("within-window-crp", "within-window", CRP, "2024-01-08"));
+        addPut(bundle, "Patient", "outside-window", patient("outside-window"));
+        addPut(bundle, "Condition", "outside-window-diagnosis",
+                condition("outside-window-diagnosis", "outside-window", DEMENTIA_DIAGNOSIS, "2024-01-10"));
+        addPut(bundle, "Observation", "outside-window-crp",
+                observation("outside-window-crp", "outside-window", CRP, "2024-01-01"));
+        fhirClient.transaction().withBundle(bundle).execute();
+
+        var libraryUri = "urn:uuid" + UUID.randomUUID();
+        var library = appendCql(parseResource(Library.class, slurp("Library.json")).setUrl(libraryUri), cql);
+        var measureUri = "urn:uuid" + UUID.randomUUID();
+        var measure = parseResource(Measure.class, slurp("Measure.json")).setUrl(measureUri).addLibrary(libraryUri);
+        fhirClient.transaction().withBundle(createBundle(library, measure)).execute();
+
+        var report = fhirClient.operation()
+                .onType(Measure.class)
+                .named("evaluate-measure")
+                .withSearchParameter(Parameters.class, "measure", new StringParam(measureUri))
+                .andSearchParameter("periodStart", new DateParam("1900"))
+                .andSearchParameter("periodEnd", new DateParam("2100"))
+                .useHttpGet()
+                .returnResourceType(MeasureReport.class)
+                .execute();
+
+        assertEquals(1, report.getGroupFirstRep().getPopulationFirstRep().getCount());
+    }
+
+    /**
+     * Verification for a real bug suspected from a user-reported anchor whose mapping supports both {@code
+     * dateTime} and {@code Period}: {@code dateProjectionExpr} (AbstractCriterion) built {@code
+     * Coalesce(ToDate(x as dateTime), (x as Period).start)} - {@code ToDate} returns {@code Date}, but {@code
+     * Period.start} is {@code DateTime}, so {@code Coalesce} mixed types across its arguments. Two patients each
+     * have a procedure coded the same way, one recorded with {@code performedDateTime}, the other with {@code
+     * performedPeriod} - if the type mismatch is a real problem, Blaze should reject the CQL library outright
+     * (an exception from the client) rather than silently misbehave, since this is a compile-time type check, not
+     * a runtime data issue.
+     */
+    @Test
+    public void evaluateAnchorWithMixedDateTimeAndPeriodTypes() throws Exception {
+        var procedure = ContextualTermCode.of(CONTEXT,
+                TermCode.of("http://fhir.de/CodeSystem/bfarm/ops", "5-812", "Arthroskopische Operation am Kniegelenk"));
+        var procedureMapping = Mapping.of(procedure, "Procedure", null, List.of(), List.of(),
+                Mapping.TimeRestrictionMapping.of("performed", DATE_TIME, PERIOD));
+        var crpMapping = Mapping.of(CRP, "Observation", null, List.of(), List.of(),
+                Mapping.TimeRestrictionMapping.of("effective", DATE_TIME));
+        var mappings = Map.of(procedure, procedureMapping, CRP, crpMapping);
+        var mappingContext = MappingContext.of(mappings, null, CODE_SYSTEM_ALIASES);
+        var translator = Translator.of(mappingContext);
+
+        var anchorGroup = Group.of("procedure", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(procedure)))),
+                Group.AnchorOccurrence.FIRST);
+        var dependentGroup = Group.of(null, List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                RelativeTimeRestriction.of("procedure", Duration.ZERO, Duration.ofHours(24)));
+        var structuredQuery = StructuredQuery.of(List.of(anchorGroup, dependentGroup));
+        var cql = translator.toCql(structuredQuery).print();
+
+        var bundle = new Bundle().setType(TRANSACTION);
+        addPut(bundle, "Patient", "dt-patient", patient("dt-patient"));
+        addPut(bundle, "Procedure", "dt-procedure", procedureWithDateTime("dt-procedure", "dt-patient", procedure, "2024-01-10"));
+        addPut(bundle, "Observation", "dt-crp", observation("dt-crp", "dt-patient", CRP, "2024-01-10"));
+        addPut(bundle, "Patient", "period-patient", patient("period-patient"));
+        addPut(bundle, "Procedure", "period-procedure",
+                procedureWithPeriod("period-procedure", "period-patient", procedure, "2024-01-10", "2024-01-10"));
+        addPut(bundle, "Observation", "period-crp", observation("period-crp", "period-patient", CRP, "2024-01-10"));
+        fhirClient.transaction().withBundle(bundle).execute();
+
+        var libraryUri = "urn:uuid" + UUID.randomUUID();
+        var library = appendCql(parseResource(Library.class, slurp("Library.json")).setUrl(libraryUri), cql);
+        var measureUri = "urn:uuid" + UUID.randomUUID();
+        var measure = parseResource(Measure.class, slurp("Measure.json")).setUrl(measureUri).addLibrary(libraryUri);
+        fhirClient.transaction().withBundle(createBundle(library, measure)).execute();
+
+        var report = fhirClient.operation()
+                .onType(Measure.class)
+                .named("evaluate-measure")
+                .withSearchParameter(Parameters.class, "measure", new StringParam(measureUri))
+                .andSearchParameter("periodStart", new DateParam("1900"))
+                .andSearchParameter("periodEnd", new DateParam("2100"))
+                .useHttpGet()
+                .returnResourceType(MeasureReport.class)
+                .execute();
+
+        assertEquals(2, report.getGroupFirstRep().getPopulationFirstRep().getCount());
+    }
+
+    private static Procedure procedureWithDateTime(String id, String patientId, ContextualTermCode concept, String date) {
+        var procedure = new Procedure();
+        procedure.setId(id);
+        procedure.setStatus(Procedure.ProcedureStatus.COMPLETED);
+        procedure.setSubject(new Reference("Patient/" + patientId));
+        procedure.getCode().addCoding().setSystem(concept.termCode().system()).setCode(concept.termCode().code());
+        procedure.setPerformed(new DateTimeType(date));
+        return procedure;
+    }
+
+    private static Procedure procedureWithPeriod(String id, String patientId, ContextualTermCode concept, String startDate, String endDate) {
+        var procedure = new Procedure();
+        procedure.setId(id);
+        procedure.setStatus(Procedure.ProcedureStatus.COMPLETED);
+        procedure.setSubject(new Reference("Patient/" + patientId));
+        procedure.getCode().addCoding().setSystem(concept.termCode().system()).setCode(concept.termCode().code());
+        procedure.setPerformed(new Period().setStartElement(new DateTimeType(startDate)).setEndElement(new DateTimeType(endDate)));
+        return procedure;
+    }
+
+    private static Patient patient(String id) {
+        var patient = new Patient();
+        patient.setId(id);
+        return patient;
+    }
+
+    private static Condition condition(String id, String patientId, ContextualTermCode concept, String onsetDate) {
+        var condition = new Condition();
+        condition.setId(id);
+        condition.setSubject(new Reference("Patient/" + patientId));
+        condition.getCode().addCoding().setSystem(concept.termCode().system()).setCode(concept.termCode().code());
+        condition.setOnset(new DateTimeType(onsetDate));
+        return condition;
+    }
+
+    private static Observation observation(String id, String patientId, ContextualTermCode concept, String effectiveDate) {
+        var observation = new Observation();
+        observation.setId(id);
+        observation.setStatus(Observation.ObservationStatus.FINAL);
+        observation.setSubject(new Reference("Patient/" + patientId));
+        observation.getCode().addCoding().setSystem(concept.termCode().system()).setCode(concept.termCode().code());
+        observation.setEffective(new DateTimeType(effectiveDate));
+        return observation;
+    }
+
+    private static void addPut(Bundle bundle, String resourceType, String id, org.hl7.fhir.r4.model.Resource resource) {
+        bundle.addEntry().setResource(resource).getRequest().setMethod(Bundle.HTTPVerb.PUT)
+                .setUrl(resourceType + "/" + id);
     }
 
     private <T extends IBaseResource> T parseResource(Class<T> type, String s) {

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/EvaluationIT.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/EvaluationIT.java
@@ -294,6 +294,125 @@ public class EvaluationIT {
     }
 
     /**
+     * Documents a confirmed Blaze/CQL gap (not a cctb bug): naive three-valued-logic reasoning says {@code X in
+     * Interval[null, null]} should be null/unknown, and a {@code where} clause with a null condition should drop
+     * the row (like SQL {@code WHERE NULL}) - so {@code exists(...)} should come out {@code false}. Blaze 0.34
+     * does not do this; the row is kept and {@code exists(...)} comes out {@code true}. Confirmed with a
+     * hand-written library carrying a literal {@code null as DateTime} instead of a real {@code Min} over an
+     * empty retrieve, to rule out {@code Min({})}-over-an-empty-retrieve as the culprit (see the real-generated-
+     * CQL version of this same gap in {@link #evaluateDependentAloneWhenAnchorNeverResolves}). Relevant because a
+     * possible future design (letting an anchor be referenceable without being independently required, e.g. for
+     * OR between differently-anchored branches) would need a dependent whose anchor never resolves to gracefully
+     * evaluate to "no match" - it currently does not, silently behaving as an unbounded window instead. Any such
+     * design would need an explicit {@code AnchorDate is not null and (...)} guard rather than relying on this.
+     */
+    @Test
+    public void evaluateNullIntervalMembershipDirectly() throws Exception {
+        var bundle = new Bundle().setType(TRANSACTION);
+        addPut(bundle, "Patient", "no-diagnosis", patient("no-diagnosis"));
+        addPut(bundle, "Observation", "no-diagnosis-crp",
+                observation("no-diagnosis-crp", "no-diagnosis", CRP, "2024-01-08"));
+        fhirClient.transaction().withBundle(bundle).execute();
+
+        var cql = """
+                library Retrieve version '1.0.0'
+                using FHIR version '4.0.0'
+                include FHIRHelpers version '4.0.0'
+
+                codesystem loinc: 'http://loinc.org'
+
+                context Patient
+
+                define InInitialPopulation:
+                  exists (from [Observation: Code '1988-5' from loinc] O
+                    where ToDate(O.effective as dateTime) in Interval[(null as DateTime) + -72 hours, (null as DateTime) + 0 hours])
+                """;
+
+        var libraryUri = "urn:uuid" + UUID.randomUUID();
+        var library = appendCql(parseResource(Library.class, slurp("Library.json")).setUrl(libraryUri), cql);
+        var measureUri = "urn:uuid" + UUID.randomUUID();
+        var measure = parseResource(Measure.class, slurp("Measure.json")).setUrl(measureUri).addLibrary(libraryUri);
+        fhirClient.transaction().withBundle(createBundle(library, measure)).execute();
+
+        var report = fhirClient.operation()
+                .onType(Measure.class)
+                .named("evaluate-measure")
+                .withSearchParameter(Parameters.class, "measure", new StringParam(measureUri))
+                .andSearchParameter("periodStart", new DateParam("1900"))
+                .andSearchParameter("periodEnd", new DateParam("2100"))
+                .useHttpGet()
+                .returnResourceType(MeasureReport.class)
+                .execute();
+
+        // Confirmed gap (see class javadoc above): should be 0 under correct null-propagation, is 1 in Blaze 0.34.
+        assertEquals(1, report.getGroupFirstRep().getPopulationFirstRep().getCount());
+    }
+
+    /**
+     * Proves the fix for the gap {@link #evaluateNullIntervalMembershipDirectly} documents at the raw-CQL level:
+     * calls {@link Group#toCql} directly on a dependent group alone, bypassing {@link Translator}'s top-level AND
+     * fold (see {@link Translator#groupsExpr}) so the anchor's own truth never independently gates the result -
+     * only the window computation, and the explicit null-guard it now carries (see {@code Group.Window}), does.
+     * This is exactly the shape a future design decoupling "referenceable as anchor" from "independently
+     * required" (e.g. for OR between differently-anchored branches) would rely on.
+     * <p>
+     * Two patients: one has no diagnosis at all (so {@code AnchorDate_diagnosis} resolves to null for them) but
+     * does have a CRP measurement that would match if the window were unbounded; the other has both the
+     * diagnosis and an in-window CRP measurement as a positive control. Only the second is counted - the guard
+     * correctly excludes the first despite Blaze's own null-propagation not doing so on its own.
+     */
+    @Test
+    public void evaluateDependentAloneWhenAnchorNeverResolves() throws Exception {
+        var diagnosisMapping = Mapping.of(DEMENTIA_DIAGNOSIS, "Condition", null, List.of(), List.of(),
+                Mapping.TimeRestrictionMapping.of("onset", Mapping.TimeRestrictionMapping.Type.DATE_TIME));
+        var crpMapping = Mapping.of(CRP, "Observation", null, List.of(), List.of(),
+                Mapping.TimeRestrictionMapping.of("effective", Mapping.TimeRestrictionMapping.Type.DATE_TIME));
+        var mappings = Map.of(DEMENTIA_DIAGNOSIS, diagnosisMapping, CRP, crpMapping);
+        var mappingContext = MappingContext.of(mappings, null, CODE_SYSTEM_ALIASES);
+
+        var anchorGroup = Group.of("diagnosis", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(DEMENTIA_DIAGNOSIS)))),
+                Group.AnchorOccurrence.FIRST);
+        var dependentGroup = Group.of(null, List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                RelativeTimeRestriction.of("diagnosis", Duration.parse("-P3D"), Duration.ZERO));
+        var allGroupsById = Map.of(anchorGroup.id(), anchorGroup);
+
+        // Isolated: only the dependent's own window-filtered criteria - no top-level AND on the anchor's own truth.
+        var cql = dependentGroup.toCql(mappingContext, allGroupsById, true)
+                .moveToPatientContext("InInitialPopulation")
+                .print();
+
+        var bundle = new Bundle().setType(TRANSACTION);
+        addPut(bundle, "Patient", "no-diagnosis", patient("no-diagnosis"));
+        addPut(bundle, "Observation", "no-diagnosis-crp",
+                observation("no-diagnosis-crp", "no-diagnosis", CRP, "2024-01-08"));
+        addPut(bundle, "Patient", "with-diagnosis", patient("with-diagnosis"));
+        addPut(bundle, "Condition", "with-diagnosis-diagnosis",
+                condition("with-diagnosis-diagnosis", "with-diagnosis", DEMENTIA_DIAGNOSIS, "2024-01-10"));
+        addPut(bundle, "Observation", "with-diagnosis-crp",
+                observation("with-diagnosis-crp", "with-diagnosis", CRP, "2024-01-08"));
+        fhirClient.transaction().withBundle(bundle).execute();
+
+        var libraryUri = "urn:uuid" + UUID.randomUUID();
+        var library = appendCql(parseResource(Library.class, slurp("Library.json")).setUrl(libraryUri), cql);
+        var measureUri = "urn:uuid" + UUID.randomUUID();
+        var measure = parseResource(Measure.class, slurp("Measure.json")).setUrl(measureUri).addLibrary(libraryUri);
+        fhirClient.transaction().withBundle(createBundle(library, measure)).execute();
+
+        var report = fhirClient.operation()
+                .onType(Measure.class)
+                .named("evaluate-measure")
+                .withSearchParameter(Parameters.class, "measure", new StringParam(measureUri))
+                .andSearchParameter("periodStart", new DateParam("1900"))
+                .andSearchParameter("periodEnd", new DateParam("2100"))
+                .useHttpGet()
+                .returnResourceType(MeasureReport.class)
+                .execute();
+
+        // Fixed: only "with-diagnosis" is counted - the explicit null-guard excludes "no-diagnosis" correctly.
+        assertEquals(1, report.getGroupFirstRep().getPopulationFirstRep().getCount());
+    }
+
+    /**
      * Verification for a real bug suspected from a user-reported anchor whose mapping supports both {@code
      * dateTime} and {@code Period}: {@code dateProjectionExpr} (AbstractCriterion) built {@code
      * Coalesce(ToDate(x as dateTime), (x as Period).start)} - {@code ToDate} returns {@code Date}, but {@code

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/TranslatorTest.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/TranslatorTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -117,7 +118,7 @@ class TranslatorTest {
 
         @Test
         void nonExpandableConcept() {
-            var structuredQuery = StructuredQuery.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(C71)))));
+            var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(C71)))))));
 
             var message = assertThrows(TranslationException.class, () -> Translator.of().toCql(structuredQuery)).getMessage();
 
@@ -131,9 +132,9 @@ class TranslatorTest {
             var conceptTree = createTreeWithChildren(C71, C71_0, C71_1);
             var mappingContext = MappingContext.of(Map.of(), conceptTree, CODE_SYSTEM_ALIASES);
 
+            var group = Group.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(C71)))));
             var message = assertThrows(TranslationException.class, () -> Translator.of(mappingContext)
-                    .toCql(StructuredQuery.of(
-                            List.of(List.of(ConceptCriterion.of(ContextualConcept.of(C71))))))).getMessage();
+                    .toCql(StructuredQuery.of(List.of(group)))).getMessage();
 
             assertEquals(
                     "Failed to expand the concept ContextualConcept[context=TermCode[system=context, code=context, display=context], concept=Concept[termCodes=[TermCode[system=http://fhir.de/CodeSystem/bfarm/icd-10-gm, code=C71, display=Malignant neoplasm of brain]]]].",
@@ -151,7 +152,7 @@ class TranslatorTest {
             var mappingContext = MappingContext.of(mappings, conceptTree, codeSystemAliases);
 
             var library = Translator.of(mappingContext).toCql(
-                    StructuredQuery.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(c71_1))))));
+                    StructuredQuery.of(List.of(Group.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(c71_1))))))));
 
             assertThat(library).printsTo("""
                     library Retrieve version '1.0.0'
@@ -181,9 +182,9 @@ class TranslatorTest {
             var codeSystemAliases = Map.of("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "icd10");
             var mappingContext = MappingContext.of(mappings, conceptTree, codeSystemAliases);
 
-            var library = Translator.of(mappingContext).toCql(StructuredQuery.of(List.of(List.of(
+            var library = Translator.of(mappingContext).toCql(StructuredQuery.of(List.of(Group.of(List.of(List.of(
                     ConceptCriterion.of(ContextualConcept.of(c71_1),
-                            TimeRestriction.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 2)))))));
+                            TimeRestriction.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 2)))))))));
 
             assertThat(library).printsTo("""
                     library Retrieve version '1.0.0'
@@ -214,8 +215,9 @@ class TranslatorTest {
             var conceptTree = createTreeWithoutChildren(c71_1);
             var codeSystemAliases = Map.of("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "icd10");
             var mappingContext = MappingContext.of(mappings, conceptTree, codeSystemAliases);
-            var query = StructuredQuery.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(c71_1),
+            var group = Group.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(c71_1),
                     TimeRestriction.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 2))))));
+            var query = StructuredQuery.of(List.of(group));
             var translator = Translator.of(mappingContext);
 
             assertThatIllegalStateException().isThrownBy(() -> translator.toCql(query)).withMessage(
@@ -234,12 +236,13 @@ class TranslatorTest {
                     createTreeRootWithoutChildren(TMZ),
                     createTreeRootWithChildren(C71, C71_0, C71_1)));
             var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
-            var structuredQuery = StructuredQuery.of(List.of(List.of(
+            var group = Group.of(List.of(List.of(
                             ConceptCriterion.of(ContextualConcept.of(C71))
                                     .appendAttributeFilter(ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED))),
                     List.of(
                             NumericCriterion.of(ContextualConcept.of(PLATELETS), LESS_THAN, BigDecimal.valueOf(50),
                                     "g/dl")), List.of(ConceptCriterion.of(ContextualConcept.of(TMZ)))));
+            var structuredQuery = StructuredQuery.of(List.of(group));
 
             var library = Translator.of(mappingContext).toCql(structuredQuery);
 
@@ -292,11 +295,12 @@ class TranslatorTest {
                     createTreeRootWithoutChildren(SERUM),
                     createTreeRootWithoutChildren(LIPID)));
             var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
-            var structuredQuery = StructuredQuery.of(List.of(List.of(
+            var inclusionGroup = Group.of(List.of(List.of(
                                     ConceptCriterion.of(ContextualConcept.of(HYPERTENSION))
                                             .appendAttributeFilter(ValueSetAttributeFilter.of(VERIFICATION_STATUS, CONFIRMED))),
-                            List.of(ConceptCriterion.of(ContextualConcept.of(SERUM)))),
-                    List.of(List.of(ConceptCriterion.of(ContextualConcept.of(LIPID)))));
+                            List.of(ConceptCriterion.of(ContextualConcept.of(SERUM)))));
+            var exclusionGroup = Group.of(List.of(List.of(ConceptCriterion.of(ContextualConcept.of(LIPID)))));
+            var structuredQuery = StructuredQuery.of(List.of(inclusionGroup), List.of(exclusionGroup));
 
             var library = Translator.of(mappingContext).toCql(structuredQuery);
 
@@ -352,12 +356,14 @@ class TranslatorTest {
                     TOBACCO_SMOKING_STATUS, Mapping.of(TOBACCO_SMOKING_STATUS, "Observation", Mapping.PathMapping.of("value", Mapping.PathMapping.Type.CODEABLE_CONCEPT)));
             var conceptTree = new MappingTreeBase(List.of(createTreeRootWithoutChildren(COPD), createTreeRootWithoutChildren(G47_31)));
             var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
-            var structuredQuery = StructuredQuery.of(
-                    List.of(List.of(ValueSetCriterion.of(ContextualConcept.of(FRAILTY_SCORE), VERY_FIT, WELL))),
+            var inclusionGroup = Group.of(
+                    List.of(List.of(ValueSetCriterion.of(ContextualConcept.of(FRAILTY_SCORE), VERY_FIT, WELL))));
+            var exclusionGroup = Group.of(
                     List.of(List.of(ConceptCriterion.of(ContextualConcept.of(COPD)),
                             ConceptCriterion.of(ContextualConcept.of(G47_31))), List.of(
                             ValueSetCriterion.of(ContextualConcept.of(TOBACCO_SMOKING_STATUS),
                                     CURRENT_EVERY_DAY_SMOKER))));
+            var structuredQuery = StructuredQuery.of(List.of(inclusionGroup), List.of(exclusionGroup));
 
             var library = Translator.of(mappingContext).toCql(structuredQuery);
 
@@ -470,22 +476,26 @@ class TranslatorTest {
                       "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                                "code": "context",
-                                "display": "context",
-                                "system": "context"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "code": "combined-consent",
-                                "system": "mii.abide",
-                                "display": "Einwilligung für die zentrale Datenanalyse"
+                                "context": {
+                                    "code": "context",
+                                    "display": "context",
+                                    "system": "context"
+                                },
+                                "termCodes": [
+                                  {
+                                    "code": "combined-consent",
+                                    "system": "mii.abide",
+                                    "display": "Einwilligung für die zentrale Datenanalyse"
+                                  }
+                                ]
                               }
                             ]
-                          }
-                        ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -542,32 +552,36 @@ class TranslatorTest {
                       "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                                "code": "context",
-                                "display": "context",
-                                "system": "context"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "code": "424144002",
-                                "system": "http://snomed.info/sct",
-                                "display": "Current chronological age"
+                                "context": {
+                                  "code": "context",
+                                  "display": "context",
+                                  "system": "context"
+                                },
+                                "termCodes": [
+                                  {
+                                    "code": "424144002",
+                                    "system": "http://snomed.info/sct",
+                                    "display": "Current chronological age"
+                                  }
+                                ],
+                                "valueFilter": {
+                                  "selectedConcepts": [],
+                                  "type": "quantity-comparator",
+                                  "unit": {
+                                    "code": "a",
+                                    "display": "a"
+                                  },
+                                  "value": 5,
+                                  "comparator": "gt"
+                                }
                               }
-                            ],
-                            "valueFilter": {
-                              "selectedConcepts": [],
-                              "type": "quantity-comparator",
-                              "unit": {
-                                "code": "a",
-                                "display": "a"
-                              },
-                              "value": 5,
-                              "comparator": "gt"
-                            }
-                          }
-                        ]
+                            ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -619,32 +633,36 @@ class TranslatorTest {
                       "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                                "code": "context",
-                                "display": "context",
-                                "system": "context"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "code": "424144002",
-                                "system": "http://snomed.info/sct",
-                                "display": "Current chronological age"
+                                "context": {
+                                  "code": "context",
+                                  "display": "context",
+                                  "system": "context"
+                                },
+                                "termCodes": [
+                                  {
+                                    "code": "424144002",
+                                    "system": "http://snomed.info/sct",
+                                    "display": "Current chronological age"
+                                  }
+                                ],
+                                "valueFilter": {
+                                  "selectedConcepts": [],
+                                  "type": "quantity-range",
+                                  "unit": {
+                                    "code": "a",
+                                    "display": "a"
+                                  },
+                                  "minValue": 5,
+                                  "maxValue": 10
+                                }
                               }
-                            ],
-                            "valueFilter": {
-                              "selectedConcepts": [],
-                              "type": "quantity-range",
-                              "unit": {
-                                "code": "a",
-                                "display": "a"
-                              },
-                              "minValue": 5,
-                              "maxValue": 10
-                            }
-                          }
-                        ]
+                            ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -696,32 +714,36 @@ class TranslatorTest {
                       "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                                "code": "context",
-                                "display": "context",
-                                "system": "context"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "code": "424144002",
-                                "system": "http://snomed.info/sct",
-                                "display": "Current chronological age"
+                                "context": {
+                                  "code": "context",
+                                  "display": "context",
+                                  "system": "context"
+                                },
+                                "termCodes": [
+                                  {
+                                    "code": "424144002",
+                                    "system": "http://snomed.info/sct",
+                                    "display": "Current chronological age"
+                                  }
+                                ],
+                                "valueFilter": {
+                                  "selectedConcepts": [],
+                                  "type": "quantity-comparator",
+                                  "unit": {
+                                    "code": "h",
+                                    "display": "h"
+                                  },
+                                  "value": 5,
+                                  "comparator": "lt"
+                                }
                               }
-                            ],
-                            "valueFilter": {
-                              "selectedConcepts": [],
-                              "type": "quantity-comparator",
-                              "unit": {
-                                "code": "h",
-                                "display": "h"
-                              },
-                              "value": 5,
-                              "comparator": "lt"
-                            }
-                          }
-                        ]
+                            ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -775,32 +797,36 @@ class TranslatorTest {
                       "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                                "code": "context",
-                                "display": "context",
-                                "system": "context"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "code": "263495000",
-                                "display": "Geschlecht",
-                                "system": "http://snomed.info/sct"
-                              }
-                            ],
-                            "valueFilter": {
-                              "type": "concept",
-                              "selectedConcepts": [
-                                {
-                                  "code": "female",
-                                  "system": "http://hl7.org/fhir/administrative-gender",
-                                  "display": "Female"
+                                "context": {
+                                  "code": "context",
+                                  "display": "context",
+                                  "system": "context"
+                                },
+                                "termCodes": [
+                                  {
+                                    "code": "263495000",
+                                    "display": "Geschlecht",
+                                    "system": "http://snomed.info/sct"
+                                  }
+                                ],
+                                "valueFilter": {
+                                  "type": "concept",
+                                  "selectedConcepts": [
+                                    {
+                                      "code": "female",
+                                      "system": "http://hl7.org/fhir/administrative-gender",
+                                      "display": "Female"
+                                    }
+                                  ]
                                 }
-                              ]
-                            }
-                          }
-                        ]
+                              }
+                            ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -857,23 +883,27 @@ class TranslatorTest {
                       "version": "http://to_be_decided.com/draft-1/schema#",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                              "code": "Einwilligung",
-                              "display": "Einwilligung",
-                              "system": "fdpg.mii.cds",
-                              "version": "1.0.0"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "code": "2.16.840.1.113883.3.1937.777.24.5.3.8",
-                                "display": "MDAT wissenschaftlich nutzen EU DSGVO NIVEAU",
-                                "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3"
+                                "context": {
+                                  "code": "Einwilligung",
+                                  "display": "Einwilligung",
+                                  "system": "fdpg.mii.cds",
+                                  "version": "1.0.0"
+                                },
+                                "termCodes": [
+                                  {
+                                    "code": "2.16.840.1.113883.3.1937.777.24.5.3.8",
+                                    "display": "MDAT wissenschaftlich nutzen EU DSGVO NIVEAU",
+                                    "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3"
+                                  }
+                                ]
                               }
                             ]
-                          }
-                        ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -933,24 +963,28 @@ class TranslatorTest {
                       "version": "http://to_be_decided.com/draft-1/schema#",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                              "code": "Fall",
-                              "display": "Fall",
-                              "system": "fdpg.mii.cds",
-                              "version": "1.0.0"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "code": "VR",
-                                "display": "virtual",
-                                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-                                "version": "9.0.0"
+                                "context": {
+                                  "code": "Fall",
+                                  "display": "Fall",
+                                  "system": "fdpg.mii.cds",
+                                  "version": "1.0.0"
+                                },
+                                "termCodes": [
+                                  {
+                                    "code": "VR",
+                                    "display": "virtual",
+                                    "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                                    "version": "9.0.0"
+                                  }
+                                ]
                               }
                             ]
-                          }
-                        ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -1012,38 +1046,42 @@ class TranslatorTest {
                       "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
                       "display": "",
                       "inclusionCriteria": [
-                        [
-                          {
-                            "context": {
-                              "code": "Laboruntersuchung",
-                              "display": "Laboruntersuchung",
-                              "system": "fdpg.mii.cds",
-                              "version": "1.0.0"
-                            },
-                            "termCodes": [
+                        {
+                          "criteria": [
+                            [
                               {
-                                "system": "http://loinc.org",
-                                "code": "85354-9",
-                                "display": "Blood pressure panel with all children optional"
-                              }
-                            ],
-                            "attributeFilters": [
-                              {
-                                "attributeCode": {
-                                  "system": "http://loinc.org",
-                                  "code": "8462-4",
-                                  "display": "Diastolic blood pressure"
+                                "context": {
+                                  "code": "Laboruntersuchung",
+                                  "display": "Laboruntersuchung",
+                                  "system": "fdpg.mii.cds",
+                                  "version": "1.0.0"
                                 },
-                                "type": "quantity-comparator",
-                                "comparator": "lt",
-                                "value": 80,
-                                "unit": {
-                                  "code": "mm[Hg]"
-                                }
+                                "termCodes": [
+                                  {
+                                    "system": "http://loinc.org",
+                                    "code": "85354-9",
+                                    "display": "Blood pressure panel with all children optional"
+                                  }
+                                ],
+                                "attributeFilters": [
+                                  {
+                                    "attributeCode": {
+                                      "system": "http://loinc.org",
+                                      "code": "8462-4",
+                                      "display": "Diastolic blood pressure"
+                                    },
+                                    "type": "quantity-comparator",
+                                    "comparator": "lt",
+                                    "value": 80,
+                                    "unit": {
+                                      "code": "mm[Hg]"
+                                    }
+                                  }
+                                ]
                               }
                             ]
-                          }
-                        ]
+                          ]
+                        }
                       ]
                     }
                     """);
@@ -1076,7 +1114,7 @@ class TranslatorTest {
 
             @Test
             void oneDisjunctionWithOneCriterion() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
@@ -1093,7 +1131,7 @@ class TranslatorTest {
 
             @Test
             void oneDisjunctionWithTwoCriteria() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE, Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE, Criterion.FALSE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
@@ -1114,19 +1152,19 @@ class TranslatorTest {
 
             @Test
             void twoDisjunctionsWithOneCriterionEach() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
                 assertThat(library).patientContextPrintsTo("""
                         context Patient
-                        
+
                         define "Criterion 1":
                           true
-                        
+
                         define "Criterion 2":
                           false
-                        
+
                         define InInitialPopulation:
                           "Criterion 1" and
                           "Criterion 2"
@@ -1135,8 +1173,8 @@ class TranslatorTest {
 
             @Test
             void twoDisjunctionsWithTwoCriterionEach() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE, Criterion.TRUE),
-                        List.of(Criterion.FALSE, Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE, Criterion.TRUE),
+                        List.of(Criterion.FALSE, Criterion.FALSE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
@@ -1169,7 +1207,8 @@ class TranslatorTest {
 
             @Test
             void oneConjunctionWithOneCriterion() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE)), List.of(List.of(Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE)))),
+                        List.of(Group.of(List.of(List.of(Criterion.FALSE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
@@ -1196,8 +1235,8 @@ class TranslatorTest {
 
             @Test
             void oneConjunctionWithTwoCriteria() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE)),
-                        List.of(List.of(Criterion.FALSE, Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE)))),
+                        List.of(Group.of(List.of(List.of(Criterion.FALSE, Criterion.FALSE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
@@ -1228,8 +1267,8 @@ class TranslatorTest {
 
             @Test
             void twoConjunctionsWithOneCriterionEach() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE)),
-                        List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE)))),
+                        List.of(Group.of(List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE)))));
 
 
                 var library = Translator.of().toCql(structuredQuery);
@@ -1261,9 +1300,9 @@ class TranslatorTest {
 
             @Test
             void twoConjunctionsWithTwoCriterionEach() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE)),
-                        List.of(List.of(Criterion.FALSE, Criterion.FALSE),
-                                List.of(Criterion.FALSE, Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE)))),
+                        List.of(Group.of(List.of(List.of(Criterion.FALSE, Criterion.FALSE),
+                                List.of(Criterion.FALSE, Criterion.FALSE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
@@ -1302,8 +1341,8 @@ class TranslatorTest {
 
             @Test
             void twoInclusionAndTwoExclusionCriteria() {
-                var structuredQuery = StructuredQuery.of(List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE)),
-                        List.of(List.of(Criterion.TRUE, Criterion.FALSE)));
+                var structuredQuery = StructuredQuery.of(List.of(Group.of(List.of(List.of(Criterion.TRUE), List.of(Criterion.FALSE)))),
+                        List.of(Group.of(List.of(List.of(Criterion.TRUE, Criterion.FALSE)))));
 
                 var library = Translator.of().toCql(structuredQuery);
 
@@ -1416,6 +1455,431 @@ class TranslatorTest {
                        """);
             }
 
+        }
+
+        @Nested
+        class RelativeTimeRestrictions {
+
+            private static final ContextualTermCode DIAGNOSIS = ContextualTermCode.of(CONTEXT,
+                    TermCode.of("http://fhir.de/CodeSystem/bfarm/icd-10-gm", "F00", "Demenz bei Alzheimer-Krankheit"));
+            private static final ContextualTermCode CRP = ContextualTermCode.of(CONTEXT,
+                    TermCode.of("http://loinc.org", "1988-5", "C-reaktives Protein"));
+            private static final ContextualTermCode LEUKOCYTES = ContextualTermCode.of(CONTEXT,
+                    TermCode.of("http://loinc.org", "6690-2", "Leukozyten"));
+            private static final ContextualTermCode HEMOGLOBIN = ContextualTermCode.of(CONTEXT,
+                    TermCode.of("http://loinc.org", "718-7", "Hemoglobin [Mass/volume] in Blood"));
+
+            private static MappingContext mappingContext(ContextualTermCode... termCodes) {
+                var diagnosisMapping = Mapping.of(DIAGNOSIS, "Condition", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("onset", DATE_TIME));
+                var crpMapping = Mapping.of(CRP, "Observation", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("effective", DATE_TIME));
+                var leukocytesMapping = Mapping.of(LEUKOCYTES, "Observation", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("effective", DATE_TIME));
+                var mappings = Map.of(DIAGNOSIS, diagnosisMapping, CRP, crpMapping, LEUKOCYTES, leukocytesMapping);
+                var conceptTree = new MappingTreeBase(List.of(createTreeRootWithoutChildren(DIAGNOSIS),
+                        createTreeRootWithoutChildren(CRP), createTreeRootWithoutChildren(LEUKOCYTES)));
+                return MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
+            }
+
+            @Test
+            void simpleAnchorAndOneDependent() {
+                var anchor = Group.of("anchor-dementia-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(DIAGNOSIS)))),
+                        Group.AnchorOccurrence.FIRST);
+                var dependent = Group.of("group-crp-before-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                        RelativeTimeRestriction.of("anchor-dementia-diagnosis", Duration.ofHours(-72), Duration.ZERO));
+                var structuredQuery = StructuredQuery.of(List.of(anchor, dependent));
+
+                var library = Translator.of(mappingContext(DIAGNOSIS, CRP)).toCql(structuredQuery);
+
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          exists [Condition: Code 'F00' from icd10]
+
+                        define "AnchorDate_anchor-dementia-diagnosis":
+                          Min(from [Condition: Code 'F00' from icd10] C
+                            return ToDate(C.onset as dateTime))
+
+                        define "Criterion 2":
+                          exists (from [Observation: Code '1988-5' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval["AnchorDate_anchor-dementia-diagnosis" + -72 hours, "AnchorDate_anchor-dementia-diagnosis" + 0 hours])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          "Criterion 2"
+                        """);
+            }
+
+            @Test
+            void fanOutTwoDependentsOnOneAnchor() {
+                var anchor = Group.of("anchor-dementia-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(DIAGNOSIS)))),
+                        Group.AnchorOccurrence.FIRST);
+                var dependent1 = Group.of("group-crp-before-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                        RelativeTimeRestriction.of("anchor-dementia-diagnosis", Duration.ofHours(-72), Duration.ZERO));
+                var dependent2 = Group.of("group-leukocytes-before-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(LEUKOCYTES)))),
+                        RelativeTimeRestriction.of("anchor-dementia-diagnosis", Duration.ofHours(-72), Duration.ZERO));
+                var structuredQuery = StructuredQuery.of(List.of(anchor, dependent1, dependent2));
+
+                var library = Translator.of(mappingContext(DIAGNOSIS, CRP, LEUKOCYTES)).toCql(structuredQuery);
+
+                // Each dependent now resolves its own anchor date exactly once (see AnchorDate_... defines below)
+                // instead of twice (one copy per bound). Across dependents, though, it is still NOT fully shared:
+                // the two "AnchorDate_anchor-dementia-diagnosis" defines get suffixed apart (`1`/`2`) rather than
+                // collapsed into one, because Container's combiner treats any same-name collision between two
+                // independently-built containers as needing disambiguation, not as a candidate for content-based
+                // dedup - a deeper fix than the per-dependent one applied here.
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          exists [Condition: Code 'F00' from icd10]
+
+                        define "AnchorDate_anchor-dementia-diagnosis 1":
+                          Min(from [Condition: Code 'F00' from icd10] C
+                            return ToDate(C.onset as dateTime))
+
+                        define "Criterion 2":
+                          exists (from [Observation: Code '1988-5' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval["AnchorDate_anchor-dementia-diagnosis 1" + -72 hours, "AnchorDate_anchor-dementia-diagnosis 1" + 0 hours])
+
+                        define "AnchorDate_anchor-dementia-diagnosis 2":
+                          Min(from [Condition: Code 'F00' from icd10] C
+                            return ToDate(C.onset as dateTime))
+
+                        define "Criterion 3":
+                          exists (from [Observation: Code '6690-2' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval["AnchorDate_anchor-dementia-diagnosis 2" + -72 hours, "AnchorDate_anchor-dementia-diagnosis 2" + 0 hours])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          "Criterion 2" and
+                          "Criterion 3"
+                        """);
+            }
+
+            @Test
+            void nowAnchor() {
+                var anchor = Group.of("anchor-now", NowCriterion.INSTANCE);
+                var dependent = Group.of("group-crp-since-now",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                        RelativeTimeRestriction.of("anchor-now", Duration.ofHours(-168), Duration.ZERO));
+                var structuredQuery = StructuredQuery.of(List.of(anchor, dependent));
+
+                var library = Translator.of(mappingContext(DIAGNOSIS, CRP)).toCql(structuredQuery);
+
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          true
+
+                        define "AnchorDate_anchor-now":
+                          Min({ Now() })
+
+                        define "Criterion 2":
+                          exists (from [Observation: Code '1988-5' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval["AnchorDate_anchor-now" + -168 hours, "AnchorDate_anchor-now" + 0 hours])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          "Criterion 2"
+                        """);
+            }
+
+            @Test
+            void openEndedMinOffsetOnly() {
+                var anchor = Group.of("anchor-dementia-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(DIAGNOSIS)))),
+                        Group.AnchorOccurrence.FIRST);
+                var dependent = Group.of("group-crp-since-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                        RelativeTimeRestriction.of("anchor-dementia-diagnosis", Duration.ofHours(-168), null));
+                var structuredQuery = StructuredQuery.of(List.of(anchor, dependent));
+
+                var library = Translator.of(mappingContext(DIAGNOSIS, CRP)).toCql(structuredQuery);
+
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          exists [Condition: Code 'F00' from icd10]
+
+                        define "AnchorDate_anchor-dementia-diagnosis":
+                          Min(from [Condition: Code 'F00' from icd10] C
+                            return ToDate(C.onset as dateTime))
+
+                        define "Criterion 2":
+                          exists (from [Observation: Code '1988-5' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval["AnchorDate_anchor-dementia-diagnosis" + -168 hours, @9999-12-31T])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          "Criterion 2"
+                        """);
+            }
+
+            @Test
+            void openEndedMaxOffsetOnly() {
+                var anchor = Group.of("anchor-dementia-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(DIAGNOSIS)))),
+                        Group.AnchorOccurrence.FIRST);
+                var dependent = Group.of("group-crp-after-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                        RelativeTimeRestriction.of("anchor-dementia-diagnosis", null, Duration.ofHours(720)));
+                var structuredQuery = StructuredQuery.of(List.of(anchor, dependent));
+
+                var library = Translator.of(mappingContext(DIAGNOSIS, CRP)).toCql(structuredQuery);
+
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          exists [Condition: Code 'F00' from icd10]
+
+                        define "AnchorDate_anchor-dementia-diagnosis":
+                          Min(from [Condition: Code 'F00' from icd10] C
+                            return ToDate(C.onset as dateTime))
+
+                        define "Criterion 2":
+                          exists (from [Observation: Code '1988-5' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval[@0001-01-01T, "AnchorDate_anchor-dementia-diagnosis" + 720 hours])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          "Criterion 2"
+                        """);
+            }
+
+            @Test
+            void chainedAnchors() {
+                var anchorNow = Group.of("anchor-now", NowCriterion.INSTANCE);
+                var middle = Group.of("group-diagnosis-since-now",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(DIAGNOSIS)))),
+                        RelativeTimeRestriction.of("anchor-now", Duration.ofHours(-720), null),
+                        Group.AnchorOccurrence.LAST);
+                var dependent = Group.of("group-crp-before-diagnosis",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                        RelativeTimeRestriction.of("group-diagnosis-since-now", Duration.ofHours(-24), Duration.ZERO));
+                var structuredQuery = StructuredQuery.of(List.of(anchorNow, middle, dependent));
+
+                var library = Translator.of(mappingContext(DIAGNOSIS, CRP)).toCql(structuredQuery);
+
+                // The chain resolves "anchor-now" once per independently-built container (its own define, deduped
+                // within each), but "group-diagnosis-since-now" (the middle group) needs it twice - once for its
+                // own Criterion 2 existence check, once when it is itself resolved as the dependent's anchor -
+                // which are two separately-built containers, so (per the same cross-container limitation noted in
+                // fanOutTwoDependentsOnOneAnchor) "AnchorDate_anchor-now" ends up suffixed apart (`1`/`2`) rather
+                // than shared.
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          true
+
+                        define "AnchorDate_anchor-now 1":
+                          Min({ Now() })
+
+                        define "Criterion 2":
+                          exists (from [Condition: Code 'F00' from icd10] C
+                            where ToDate(C.onset as dateTime) in Interval["AnchorDate_anchor-now 1" + -720 hours, @9999-12-31T])
+
+                        define "AnchorDate_anchor-now 2":
+                          Min({ Now() })
+
+                        define "AnchorDate_group-diagnosis-since-now":
+                          Max(from [Condition: Code 'F00' from icd10] C
+                            where ToDate(C.onset as dateTime) in Interval["AnchorDate_anchor-now 2" + -720 hours, @9999-12-31T]
+                            return ToDate(C.onset as dateTime))
+
+                        define "Criterion 3":
+                          exists (from [Observation: Code '1988-5' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval["AnchorDate_group-diagnosis-since-now" + -24 hours, "AnchorDate_group-diagnosis-since-now" + 0 hours])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          "Criterion 2" and
+                          "Criterion 3"
+                        """);
+            }
+
+            /**
+             * Regression test for a real bug found via external review of the generated CQL: an anchor whose
+             * mapping can be {@code PERIOD}-typed (a real, common case - e.g. {@code Procedure.performed}) needs
+             * its {@code .start}/{@code .end} access parenthesized around the {@code as Period} cast. See
+             * {@link de.medizininformatikinitiative.cctb.model.cql.InvocationExpressionTest} for the isolated
+             * AST-level regression test; this one proves it end to end through the real translation path, which
+             * no other {@code RelativeTimeRestrictions} test above exercises (they're all {@code DATE_TIME}-only
+             * anchors).
+             */
+            @Test
+            void periodTypedAnchorPoint() {
+                var procedure = ContextualTermCode.of(CONTEXT,
+                        TermCode.of("http://fhir.de/CodeSystem/bfarm/ops", "5-812", "Arthroskopische Operation am Kniegelenk"));
+                var procedureMapping = Mapping.of(procedure, "Procedure", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("performed", DATE_TIME, PERIOD));
+                var crpMapping = Mapping.of(CRP, "Observation", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("effective", DATE_TIME));
+                var mappings = Map.of(procedure, procedureMapping, CRP, crpMapping);
+                var conceptTree = new MappingTreeBase(List.of(createTreeRootWithoutChildren(procedure),
+                        createTreeRootWithoutChildren(CRP)));
+                var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
+
+                var anchor = Group.of("anchor-procedure",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(procedure)))),
+                        Group.AnchorOccurrence.FIRST, Group.AnchorPoint.START);
+                var dependent = Group.of("group-crp-after-procedure",
+                        List.of(List.of(ConceptCriterion.of(ContextualConcept.of(CRP)))),
+                        RelativeTimeRestriction.of("anchor-procedure", Duration.ZERO, Duration.ofHours(24)));
+                var structuredQuery = StructuredQuery.of(List.of(anchor, dependent));
+
+                var library = Translator.of(mappingContext).toCql(structuredQuery);
+
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem codeSystem1: 'http://fhir.de/CodeSystem/bfarm/ops'
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          exists [Procedure: Code '5-812' from codeSystem1]
+
+                        define "AnchorDate_anchor-procedure":
+                          Min(from [Procedure: Code '5-812' from codeSystem1] P
+                            return Coalesce(ToDate(P.performed as dateTime), ToDate((P.performed as Period).start)))
+
+                        define "Criterion 2":
+                          exists (from [Observation: Code '1988-5' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval["AnchorDate_anchor-procedure" + 0 hours, "AnchorDate_anchor-procedure" + 24 hours])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          "Criterion 2"
+                        """);
+            }
+
+            /**
+             * Direct test of the asymmetric min/max-across-clauses rule for AND-groups as anchors: anchor =
+             * DIAGNOSIS AND (CRP or LEUKOCYTES), dependent = HEMOGLOBIN within [0h, 24h] of the anchor. Expects
+             * the {@code maxOffset} bound (window end) to be built from {@code Min} across the two clauses, and
+             * the {@code minOffset} bound (window start) from {@code Max} - the opposite of what a naive
+             * single-collapsed-anchor-point implementation would produce.
+             */
+            @Test
+            void multiClauseAnchor() {
+                var diagnosisMapping = Mapping.of(DIAGNOSIS, "Condition", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("onset", DATE_TIME));
+                var crpMapping = Mapping.of(CRP, "Observation", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("effective", DATE_TIME));
+                var leukocytesMapping = Mapping.of(LEUKOCYTES, "Observation", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("effective", DATE_TIME));
+                var hemoglobinMapping = Mapping.of(HEMOGLOBIN, "Observation", null, List.of(), List.of(),
+                        Mapping.TimeRestrictionMapping.of("effective", DATE_TIME));
+                var mappings = Map.of(DIAGNOSIS, diagnosisMapping, CRP, crpMapping, LEUKOCYTES, leukocytesMapping,
+                        HEMOGLOBIN, hemoglobinMapping);
+                var conceptTree = new MappingTreeBase(List.of(createTreeRootWithoutChildren(DIAGNOSIS),
+                        createTreeRootWithoutChildren(CRP), createTreeRootWithoutChildren(LEUKOCYTES),
+                        createTreeRootWithoutChildren(HEMOGLOBIN)));
+                var mappingContext = MappingContext.of(mappings, conceptTree, CODE_SYSTEM_ALIASES);
+
+                var anchor = Group.of("anchor", List.of(
+                        List.of(ConceptCriterion.of(ContextualConcept.of(DIAGNOSIS))),
+                        List.of(ConceptCriterion.of(ContextualConcept.of(CRP)), ConceptCriterion.of(ContextualConcept.of(LEUKOCYTES)))),
+                        Group.AnchorOccurrence.FIRST);
+                var dependent = Group.of("dependent", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(HEMOGLOBIN)))),
+                        RelativeTimeRestriction.of("anchor", Duration.ZERO, Duration.ofHours(24)));
+                var structuredQuery = StructuredQuery.of(List.of(anchor, dependent));
+
+                var library = Translator.of(mappingContext).toCql(structuredQuery);
+
+                assertThat(library).printsTo("""
+                        library Retrieve version '1.0.0'
+                        using FHIR version '4.0.0'
+                        include FHIRHelpers version '4.0.0'
+
+                        codesystem icd10: 'http://fhir.de/CodeSystem/bfarm/icd-10-gm'
+                        codesystem loinc: 'http://loinc.org'
+
+                        context Patient
+
+                        define "Criterion 1":
+                          exists [Condition: Code 'F00' from icd10]
+
+                        define "Criterion 2":
+                          exists [Observation: Code '1988-5' from loinc]
+
+                        define "Criterion 3":
+                          exists [Observation: Code '6690-2' from loinc]
+
+                        define AnchorDate_anchor:
+                          { Min(from [Condition: Code 'F00' from icd10] C
+                            return ToDate(C.onset as dateTime)), Min((from [Observation: Code '1988-5' from loinc] O
+                            return ToDate(O.effective as dateTime)) union
+                          (from [Observation: Code '6690-2' from loinc] O
+                            return ToDate(O.effective as dateTime))) }
+
+                        define "Criterion 4":
+                          exists (from [Observation: Code '718-7' from loinc] O
+                            where ToDate(O.effective as dateTime) in Interval[Max(AnchorDate_anchor) + 0 hours, Min(AnchorDate_anchor) + 24 hours])
+
+                        define InInitialPopulation:
+                          "Criterion 1" and
+                          ("Criterion 2" or
+                          "Criterion 3") and
+                          "Criterion 4"
+                        """);
+            }
         }
     }
 }

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/TranslatorTest.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/TranslatorTest.java
@@ -1517,6 +1517,7 @@ class TranslatorTest {
 
                         define InInitialPopulation:
                           "Criterion 1" and
+                          "AnchorDate_anchor-dementia-diagnosis" is not null and
                           "Criterion 2"
                         """);
             }
@@ -1573,7 +1574,9 @@ class TranslatorTest {
 
                         define InInitialPopulation:
                           "Criterion 1" and
+                          "AnchorDate_anchor-dementia-diagnosis 1" is not null and
                           "Criterion 2" and
+                          "AnchorDate_anchor-dementia-diagnosis 2" is not null and
                           "Criterion 3"
                         """);
             }
@@ -1609,6 +1612,7 @@ class TranslatorTest {
 
                         define InInitialPopulation:
                           "Criterion 1" and
+                          "AnchorDate_anchor-now" is not null and
                           "Criterion 2"
                         """);
             }
@@ -1648,6 +1652,7 @@ class TranslatorTest {
 
                         define InInitialPopulation:
                           "Criterion 1" and
+                          "AnchorDate_anchor-dementia-diagnosis" is not null and
                           "Criterion 2"
                         """);
             }
@@ -1687,6 +1692,7 @@ class TranslatorTest {
 
                         define InInitialPopulation:
                           "Criterion 1" and
+                          "AnchorDate_anchor-dementia-diagnosis" is not null and
                           "Criterion 2"
                         """);
             }
@@ -1711,6 +1717,11 @@ class TranslatorTest {
                 // which are two separately-built containers, so (per the same cross-container limitation noted in
                 // fanOutTwoDependentsOnOneAnchor) "AnchorDate_anchor-now" ends up suffixed apart (`1`/`2`) rather
                 // than shared.
+                //
+                // Note the guard only appears once here, on Criterion 2 - not on "AnchorDate_anchor-now 2", which
+                // feeds AnchorDate_group-diagnosis-since-now's own candidate filtering via the chaining path in
+                // resolveAnchorDates. That path doesn't yet apply the guard (see the comment there); only the
+                // final criterion-matching path in combineCriteria does. Known, scoped-out gap for chained anchors.
                 assertThat(library).printsTo("""
                         library Retrieve version '1.0.0'
                         using FHIR version '4.0.0'
@@ -1745,7 +1756,9 @@ class TranslatorTest {
 
                         define InInitialPopulation:
                           "Criterion 1" and
+                          "AnchorDate_anchor-now 1" is not null and
                           "Criterion 2" and
+                          "AnchorDate_group-diagnosis-since-now" is not null and
                           "Criterion 3"
                         """);
             }
@@ -1805,6 +1818,7 @@ class TranslatorTest {
 
                         define InInitialPopulation:
                           "Criterion 1" and
+                          "AnchorDate_anchor-procedure" is not null and
                           "Criterion 2"
                         """);
             }
@@ -1877,6 +1891,8 @@ class TranslatorTest {
                           "Criterion 1" and
                           ("Criterion 2" or
                           "Criterion 3") and
+                          Min(AnchorDate_anchor) is not null and
+                          Max(AnchorDate_anchor) is not null and
                           "Criterion 4"
                         """);
             }

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/model/cql/InvocationExpressionTest.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/model/cql/InvocationExpressionTest.java
@@ -1,0 +1,31 @@
+package de.medizininformatikinitiative.cctb.model.cql;
+
+import de.medizininformatikinitiative.cctb.PrintContext;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class InvocationExpressionTest {
+
+    @Test
+    void print_IdentifierBase() {
+        var cql = InvocationExpression.of(StandardIdentifierExpression.of("O"), "effective").print(PrintContext.ZERO);
+
+        assertEquals("O.effective", cql);
+    }
+
+    /**
+     * A regression test for a real bug found via external review of generated CQL: accessing a member on a
+     * type-cast expression (e.g. reading {@code .start} off a value cast to {@code Period}) must parenthesize the
+     * cast, since {@code as} binds more loosely than accessor - printing it bare (as it did before this fix)
+     * produces {@code x as Period.start}, which a CQL parser would try to read as casting to a (nonsensical)
+     * qualified type named {@code Period.start} rather than the intended {@code (x as Period).start}.
+     */
+    @Test
+    void print_LowerPrecedenceBase() {
+        var cast = TypeExpression.of(InvocationExpression.of(StandardIdentifierExpression.of("P"), "performed"), "Period");
+        var cql = InvocationExpression.of(cast, "start").print(PrintContext.ZERO);
+
+        assertEquals("(P.performed as Period).start", cql);
+    }
+}

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/CriterionTest.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/CriterionTest.java
@@ -2,6 +2,7 @@ package de.medizininformatikinitiative.cctb.model.structured_query;
 
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
+import de.medizininformatikinitiative.cctb.model.MappingContext;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,26 @@ class CriterionTest {
             assertThatThrownBy(() -> mapper.readValue("{}", Criterion.class))
                     .isInstanceOf(JacksonException.class)
                     .hasRootCauseMessage("missing JSON property: context");
+        }
+
+        @Test
+        void nowCriterion() throws JacksonException {
+            var criterion = mapper.readValue("""
+                    {"type": "now"}
+                    """, Criterion.class);
+
+            assertThat(criterion).isSameAs(NowCriterion.INSTANCE);
+        }
+
+        @Test
+        void nowCriterionIgnoresOtherProperties() throws JacksonException {
+            // a "now" criterion is recognized purely by its "type" discriminator, before context/termCodes are
+            // required - this must not throw even though context/termCodes are absent
+            var criterion = mapper.readValue("""
+                    {"type": "now", "timeRestriction": {"afterDate": "2020-01-01"}}
+                    """, Criterion.class);
+
+            assertThat(criterion).isSameAs(NowCriterion.INSTANCE);
         }
 
         @Test
@@ -257,6 +278,44 @@ class CriterionTest {
                 assertThat(referencedCriterion.timeRestriction())
                         .isEqualTo(TimeRestriction.of(LocalDate.of(2024, 11, 20), LocalDate.of(2024, 11, 20)));
             }
+        }
+    }
+
+    @Nested
+    class NowCriterionBehavior {
+
+        private static final MappingContext EMPTY_MAPPING_CONTEXT = MappingContext.of();
+
+        @Test
+        void alwaysMatches() {
+            de.medizininformatikinitiative.cctb.Assertions.assertThat(NowCriterion.INSTANCE.toCql(EMPTY_MAPPING_CONTEXT))
+                    .printsTo("""
+                            library Retrieve version '1.0.0'
+                            using FHIR version '4.0.0'
+                            include FHIRHelpers version '4.0.0'
+
+                            context Patient
+
+                            define Criterion:
+                              true
+                            """);
+        }
+
+        @Test
+        void dateValuesExprIsNow() {
+            de.medizininformatikinitiative.cctb.Assertions.assertThat(
+                            NowCriterion.INSTANCE.dateValuesExpr(EMPTY_MAPPING_CONTEXT, Group.AnchorPoint.START))
+                    .printsTo("""
+                            library Retrieve version '1.0.0'
+                            using FHIR version '4.0.0'
+                            include FHIRHelpers version '4.0.0'
+                            """);
+        }
+
+        @Test
+        void toReferencesCqlIsUnsupported() {
+            assertThatThrownBy(() -> NowCriterion.INSTANCE.toReferencesCql(EMPTY_MAPPING_CONTEXT))
+                    .isInstanceOf(UnsupportedOperationException.class);
         }
     }
 }

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/GroupTest.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/GroupTest.java
@@ -1,0 +1,186 @@
+package de.medizininformatikinitiative.cctb.model.structured_query;
+
+import tools.jackson.databind.ObjectMapper;
+import de.medizininformatikinitiative.cctb.model.common.TermCode;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GroupTest {
+
+    static final TermCode CONTEXT = TermCode.of("context", "context", "context");
+    static final ContextualTermCode TC_1 = ContextualTermCode.of(CONTEXT, TermCode.of("tc", "1", ""));
+
+    @Nested
+    class Construction {
+
+        @Test
+        void emptyCriteriaFails() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> Group.of(List.<List<Criterion>>of()));
+        }
+
+        @Test
+        void allEmptyClausesFails() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> Group.of(List.of(List.<Criterion>of())));
+        }
+
+        @Test
+        void ofCriterionVarargs() {
+            var group = Group.of(ConceptCriterion.of(ContextualConcept.of(TC_1)));
+
+            assertThat(group.id()).isNull();
+            assertThat(group.criteria()).hasSize(1);
+            assertThat(group.criteria().get(0)).hasSize(1);
+        }
+
+        @Test
+        void ofWithIdAndAnchorOccurrence() {
+            var group = Group.of("anchor", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                    Group.AnchorOccurrence.FIRST);
+
+            assertThat(group.id()).isEqualTo("anchor");
+            assertThat(group.anchorOccurrence()).isEqualTo(Group.AnchorOccurrence.FIRST);
+            assertThat(group.relativeTimeRestriction()).isNull();
+        }
+
+        @Test
+        void ofWithRelativeTimeRestriction() {
+            var relativeTimeRestriction = RelativeTimeRestriction.of("anchor", Duration.ofHours(-72), Duration.ZERO);
+            var group = Group.of("dependent", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                    relativeTimeRestriction);
+
+            assertThat(group.relativeTimeRestriction()).isEqualTo(relativeTimeRestriction);
+        }
+
+        @Test
+        void isNowGroup() {
+            assertThat(Group.of("now-anchor", NowCriterion.INSTANCE).isNowGroup()).isTrue();
+            assertThat(Group.of(ConceptCriterion.of(ContextualConcept.of(TC_1))).isNowGroup()).isFalse();
+        }
+    }
+
+    @Nested
+    class Deserialization {
+
+        private static final ObjectMapper MAPPER = new ObjectMapper();
+
+        @Test
+        void emptyCriteriaFails() {
+            assertThatThrownBy(() -> MAPPER.readValue("""
+                    {"criteria": []}
+                    """, Group.class))
+                    .hasRootCauseMessage("empty criteria in group");
+        }
+
+        @Test
+        void emptyCriteriaFailsWithGroupIdInMessage() {
+            assertThatThrownBy(() -> MAPPER.readValue("""
+                    {"id": "g1", "criteria": [[]]}
+                    """, Group.class))
+                    .hasRootCauseMessage("empty criteria in group `g1`");
+        }
+
+        @Test
+        void minimalGroup() {
+            var group = MAPPER.readValue("""
+                    {
+                      "criteria": [[{
+                        "context": {
+                          "system": "context",
+                          "code": "context",
+                          "display": "context"
+                        },
+                        "termCodes": [{
+                          "system": "tc",
+                          "code": "1",
+                          "display": ""
+                        }]
+                      }]]
+                    }
+                    """, Group.class);
+
+            assertThat(group.id()).isNull();
+            assertThat(group.criteria()).hasSize(1);
+            assertThat(group.relativeTimeRestriction()).isNull();
+            assertThat(group.anchorOccurrence()).isNull();
+            assertThat(group.anchorPoint()).isNull();
+        }
+
+        @Test
+        void anchorGroupWithOccurrenceAndPoint() {
+            var group = MAPPER.readValue("""
+                    {
+                      "id": "anchor-dementia-diagnosis",
+                      "anchorOccurrence": "first",
+                      "anchorPoint": "start",
+                      "criteria": [[{
+                        "context": {
+                          "system": "context",
+                          "code": "context",
+                          "display": "context"
+                        },
+                        "termCodes": [{
+                          "system": "tc",
+                          "code": "1",
+                          "display": ""
+                        }]
+                      }]]
+                    }
+                    """, Group.class);
+
+            assertThat(group.id()).isEqualTo("anchor-dementia-diagnosis");
+            assertThat(group.anchorOccurrence()).isEqualTo(Group.AnchorOccurrence.FIRST);
+            assertThat(group.anchorPoint()).isEqualTo(Group.AnchorPoint.START);
+        }
+
+        @Test
+        void dependentGroupWithRelativeTimeRestriction() {
+            var group = MAPPER.readValue("""
+                    {
+                      "id": "group-infection-signs-before-diagnosis",
+                      "relativeTimeRestriction": {
+                        "anchorRef": "anchor-dementia-diagnosis",
+                        "minOffset": "-P3D",
+                        "maxOffset": "P0D"
+                      },
+                      "criteria": [[{
+                        "context": {
+                          "system": "context",
+                          "code": "context",
+                          "display": "context"
+                        },
+                        "termCodes": [{
+                          "system": "tc",
+                          "code": "1",
+                          "display": ""
+                        }]
+                      }]]
+                    }
+                    """, Group.class);
+
+            assertThat(group.relativeTimeRestriction().anchorRef()).isEqualTo("anchor-dementia-diagnosis");
+            assertThat(group.relativeTimeRestriction().minOffset()).isEqualTo(Duration.ofDays(-3));
+            assertThat(group.relativeTimeRestriction().maxOffset()).isEqualTo(Duration.ZERO);
+        }
+
+        @Test
+        void nowCriterionGroup() {
+            var group = MAPPER.readValue("""
+                    {
+                      "id": "anchor-now",
+                      "criteria": [[{"type": "now"}]]
+                    }
+                    """, Group.class);
+
+            assertThat(group.isNowGroup()).isTrue();
+        }
+    }
+}

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/RelativeTimeRestrictionTest.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/RelativeTimeRestrictionTest.java
@@ -1,0 +1,104 @@
+package de.medizininformatikinitiative.cctb.model.structured_query;
+
+import tools.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RelativeTimeRestrictionTest {
+
+    @Nested
+    class Construction {
+
+        @Test
+        void neitherMinOffsetNorMaxOffsetFails() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> RelativeTimeRestriction.of("anchor", null, null))
+                    .withMessage("Invalid relative time restriction: at least one of minOffset/maxOffset is required.");
+        }
+
+        @Test
+        void minOffsetAfterMaxOffsetFails() {
+            assertThatExceptionOfType(IllegalArgumentException.class)
+                    .isThrownBy(() -> RelativeTimeRestriction.of("anchor", Duration.ofHours(2), Duration.ofHours(1)));
+        }
+
+        @Test
+        void onlyMinOffset() {
+            var relativeTimeRestriction = RelativeTimeRestriction.of("anchor", Duration.ofHours(-3), null);
+
+            assertThat(relativeTimeRestriction.anchorRef()).isEqualTo("anchor");
+            assertThat(relativeTimeRestriction.minOffset()).isEqualTo(Duration.ofHours(-3));
+            assertThat(relativeTimeRestriction.maxOffset()).isNull();
+        }
+
+        @Test
+        void onlyMaxOffset() {
+            var relativeTimeRestriction = RelativeTimeRestriction.of("anchor", null, Duration.ofHours(30 * 24));
+
+            assertThat(relativeTimeRestriction.anchorRef()).isEqualTo("anchor");
+            assertThat(relativeTimeRestriction.minOffset()).isNull();
+            assertThat(relativeTimeRestriction.maxOffset()).isEqualTo(Duration.ofDays(30));
+        }
+    }
+
+    @Nested
+    class Deserialization {
+
+        private static final ObjectMapper MAPPER = new ObjectMapper();
+
+        @Test
+        void signedIsoDurations() {
+            var relativeTimeRestriction = MAPPER.readValue("""
+                    {
+                      "anchorRef": "anchor-dementia-diagnosis",
+                      "minOffset": "-P3D",
+                      "maxOffset": "P0D"
+                    }
+                    """, RelativeTimeRestriction.class);
+
+            assertThat(relativeTimeRestriction.anchorRef()).isEqualTo("anchor-dementia-diagnosis");
+            assertThat(relativeTimeRestriction.minOffset()).isEqualTo(Duration.ofDays(-3));
+            assertThat(relativeTimeRestriction.maxOffset()).isEqualTo(Duration.ZERO);
+        }
+
+        @Test
+        void subDayPrecisionOffset() {
+            var relativeTimeRestriction = MAPPER.readValue("""
+                    {
+                      "anchorRef": "anchor",
+                      "maxOffset": "PT72H"
+                    }
+                    """, RelativeTimeRestriction.class);
+
+            assertThat(relativeTimeRestriction.minOffset()).isNull();
+            assertThat(relativeTimeRestriction.maxOffset()).isEqualTo(Duration.ofHours(72));
+        }
+
+        @Test
+        void missingAnchorRef() {
+            assertThatThrownBy(() -> MAPPER.readValue("""
+                    {
+                      "minOffset": "P0D"
+                    }
+                    """, RelativeTimeRestriction.class))
+                    .hasRootCauseMessage("missing JSON property: anchorRef");
+        }
+
+        @Test
+        void missingBothOffsets() {
+            assertThatThrownBy(() -> MAPPER.readValue("""
+                    {
+                      "anchorRef": "anchor"
+                    }
+                    """, RelativeTimeRestriction.class))
+                    .hasRootCauseMessage(
+                            "Invalid relative time restriction: at least one of minOffset/maxOffset is required.");
+        }
+    }
+}

--- a/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/StructuredQueryTest.java
+++ b/cql/src/test/java/de/medizininformatikinitiative/cctb/model/structured_query/StructuredQueryTest.java
@@ -3,8 +3,13 @@ package de.medizininformatikinitiative.cctb.model.structured_query;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.exc.ValueInstantiationException;
 import de.medizininformatikinitiative.cctb.model.common.TermCode;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -19,160 +24,268 @@ class StructuredQueryTest {
     static final ContextualTermCode TC_1 = ContextualTermCode.of(CONTEXT, TC_1_TC);
     static final ContextualTermCode TC_2 = ContextualTermCode.of(CONTEXT, TC_2_TC);
 
+    @Nested
+    class FromJson {
 
-    @Test
-    void fromJson_NoInclusionCriteria() {
-        var mapper = new ObjectMapper();
+        @Test
+        void noInclusionCriteria() {
+            var mapper = new ObjectMapper();
 
-        assertThrows(ValueInstantiationException.class, () -> mapper.readValue("""
-                {"inclusionCriteria": [[]]}
-                """, StructuredQuery.class));
+            assertThrows(ValueInstantiationException.class, () -> mapper.readValue("""
+                    {"inclusionCriteria": []}
+                    """, StructuredQuery.class));
+        }
+
+        @Test
+        void oneInclusionCriteria() throws Exception {
+            var mapper = new ObjectMapper();
+
+            var structuredQuery = mapper.readValue("""
+                    {"inclusionCriteria": [{"criteria": [[{
+                      "context": {
+                        "system": "context",
+                        "code": "context",
+                        "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "1",
+                        "display": ""
+                      }]
+                    }]]}]}
+                    """, StructuredQuery.class);
+
+            assertEquals(ContextualConcept.of(TC_1),
+                    structuredQuery.inclusionCriteria().get(0).criteria().get(0).get(0).getConcept());
+        }
+
+        @Test
+        void additionalPropertyIsIgnored() throws Exception {
+            var mapper = new ObjectMapper();
+
+            var structuredQuery = mapper.readValue("""
+                    {"foo-151633": "bar-151639",
+                     "inclusionCriteria": [{"criteria": [[{
+                      "context": {
+                        "system": "context",
+                        "code": "context",
+                        "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "1",
+                        "display": ""
+                      }]
+                    }]]}]}
+                    """, StructuredQuery.class);
+
+            assertEquals(ContextualConcept.of(TC_1),
+                    structuredQuery.inclusionCriteria().get(0).criteria().get(0).get(0).getConcept());
+        }
+
+        @Test
+        void twoInclusionCriteriaAnd() throws Exception {
+            var mapper = new ObjectMapper();
+
+            var structuredQuery = mapper.readValue("""
+                    {"inclusionCriteria": [{"criteria": [[{
+                      "context": {
+                        "system": "context",
+                        "code": "context",
+                        "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "1",
+                        "display": ""
+                      }]
+                    }], [{
+                      "context": {
+                          "system": "context",
+                          "code": "context",
+                          "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "2",
+                        "display": ""
+                      }]
+                    }]]}]}
+                    """, StructuredQuery.class);
+
+            assertEquals(ContextualConcept.of(TC_1),
+                    structuredQuery.inclusionCriteria().get(0).criteria().get(0).get(0).getConcept());
+            assertEquals(ContextualConcept.of(TC_2),
+                    structuredQuery.inclusionCriteria().get(0).criteria().get(1).get(0).getConcept());
+        }
+
+        @Test
+        void twoInclusionCriteriaOr() throws Exception {
+            var mapper = new ObjectMapper();
+
+            var structuredQuery = mapper.readValue("""
+                    {"inclusionCriteria": [{"criteria": [[{
+                      "context": {
+                        "system": "context",
+                        "code": "context",
+                        "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "1",
+                        "display": ""
+                      }]
+                    }, {
+                      "context": {
+                          "system": "context",
+                          "code": "context",
+                          "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "2",
+                        "display": ""
+                      }]
+                    }]]}]}
+                    """, StructuredQuery.class);
+
+            assertEquals(ContextualConcept.of(TC_1),
+                    structuredQuery.inclusionCriteria().get(0).criteria().get(0).get(0).getConcept());
+            assertEquals(ContextualConcept.of(TC_2),
+                    structuredQuery.inclusionCriteria().get(0).criteria().get(0).get(1).getConcept());
+        }
+
+        @Test
+        void oneInclusionCriteria_oneExclusionCriteria() throws Exception {
+            var mapper = new ObjectMapper();
+
+            var structuredQuery = mapper.readValue("""
+                    {"inclusionCriteria": [{"criteria": [[{
+                      "context": {
+                        "system": "context",
+                        "code": "context",
+                        "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "1",
+                        "display": ""
+                      }]
+                    }]]}], "exclusionCriteria": [{"criteria": [[{
+                      "context": {
+                        "system": "context",
+                        "code": "context",
+                        "display": "context"
+                      },
+                      "termCodes": [{
+                        "system": "tc",
+                        "code": "2",
+                        "display": ""
+                      }]
+                    }]]}]}
+                    """, StructuredQuery.class);
+
+            assertEquals(ContextualConcept.of(TC_1),
+                    structuredQuery.inclusionCriteria().get(0).criteria().get(0).get(0).getConcept());
+            assertEquals(ContextualConcept.of(TC_2),
+                    structuredQuery.exclusionCriteria().get(0).criteria().get(0).get(0).getConcept());
+        }
     }
 
-    @Test
-    void fromJson_OneInclusionCriteria() throws Exception {
-        var mapper = new ObjectMapper();
+    @Nested
+    class Validation {
 
-        var structuredQuery = mapper.readValue("""
-                {"inclusionCriteria": [[{
-                  "context": {
-                    "system": "context",
-                    "code": "context",
-                    "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "1",
-                    "display": ""
-                  }]
-                }]]}
-                """, StructuredQuery.class);
+        @Test
+        void emptyInclusionCriteria() {
+            assertThrows(IllegalArgumentException.class, () -> StructuredQuery.of(List.of()));
+        }
 
-        assertEquals(ContextualConcept.of(TC_1), structuredQuery.inclusionCriteria().get(0).get(0).getConcept());
-    }
+        @Test
+        void duplicateGroupId() {
+            var groups = List.of(
+                    Group.of("g1", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1))))),
+                    Group.of("g1", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_2))))));
 
-    @Test
-    void fromJson_AdditionalPropertyIsIgnored() throws Exception {
-        var mapper = new ObjectMapper();
+            var message = assertThrows(IllegalArgumentException.class, () -> StructuredQuery.of(groups)).getMessage();
 
-        var structuredQuery = mapper.readValue("""
-                {"foo-151633": "bar-151639",
-                 "inclusionCriteria": [[{
-                  "context": {
-                    "system": "context",
-                    "code": "context",
-                    "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "1",
-                    "display": ""
-                  }]
-                }]]}
-                """, StructuredQuery.class);
+            assertEquals("Duplicate group id `g1`.", message);
+        }
 
-        assertEquals(ContextualConcept.of(TC_1), structuredQuery.inclusionCriteria().get(0).get(0).getConcept());
-    }
+        @Test
+        void danglingAnchorRef() {
+            var groups = List.of(Group.of("dependent", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                    RelativeTimeRestriction.of("unknown-anchor", Duration.ofHours(1), null)));
 
-    @Test
-    void fromJson_TwoInclusionCriteriaAnd() throws Exception {
-        var mapper = new ObjectMapper();
+            var message = assertThrows(IllegalArgumentException.class, () -> StructuredQuery.of(groups)).getMessage();
 
-        var structuredQuery = mapper.readValue("""
-                {"inclusionCriteria": [[{
-                  "context": {
-                    "system": "context",
-                    "code": "context",
-                    "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "1",
-                    "display": ""
-                  }]
-                }], [{
-                  "context": {
-                      "system": "context",
-                      "code": "context",
-                      "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "2",
-                    "display": ""
-                  }]
-                }]]}
-                """, StructuredQuery.class);
+            assertEquals("Unknown anchorRef `unknown-anchor` in group `dependent`.", message);
+        }
 
-        assertEquals(ContextualConcept.of(TC_1), structuredQuery.inclusionCriteria().get(0).get(0).getConcept());
-        assertEquals(ContextualConcept.of(TC_2), structuredQuery.inclusionCriteria().get(1).get(0).getConcept());
-    }
+        @Test
+        void anchorRefCycle() {
+            var groups = List.of(
+                    Group.of("a", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                            RelativeTimeRestriction.of("b", Duration.ofHours(1), null), Group.AnchorOccurrence.FIRST),
+                    Group.of("b", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_2)))),
+                            RelativeTimeRestriction.of("a", Duration.ofHours(1), null), Group.AnchorOccurrence.FIRST));
 
-    @Test
-    void fromJson_TwoInclusionCriteriaOr() throws Exception {
-        var mapper = new ObjectMapper();
+            var message = assertThrows(IllegalArgumentException.class, () -> StructuredQuery.of(groups)).getMessage();
 
-        var structuredQuery = mapper.readValue("""
-                {"inclusionCriteria": [[{
-                  "context": {
-                    "system": "context",
-                    "code": "context",
-                    "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "1",
-                    "display": ""
-                  }]
-                }, {
-                  "context": {
-                      "system": "context",
-                      "code": "context",
-                      "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "2",
-                    "display": ""
-                  }]
-                }]]}
-                """, StructuredQuery.class);
+            assertEquals(true, message.startsWith("Cyclic anchorRef graph detected:"));
+        }
 
-        assertEquals(ContextualConcept.of(TC_1), structuredQuery.inclusionCriteria().get(0).get(0).getConcept());
-        assertEquals(ContextualConcept.of(TC_2), structuredQuery.inclusionCriteria().get(0).get(1).getConcept());
-    }
+        @Test
+        void anchorRefSelfCycle() {
+            var groups = List.of(Group.of("a", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                    RelativeTimeRestriction.of("a", Duration.ofHours(1), null), Group.AnchorOccurrence.FIRST));
 
-    @Test
-    void fromJson_OneInclusionCriteria_OneExclusionCriteria() throws Exception {
-        var mapper = new ObjectMapper();
+            assertThrows(IllegalArgumentException.class, () -> StructuredQuery.of(groups));
+        }
 
-        var structuredQuery = mapper.readValue("""
-                {"inclusionCriteria": [[{
-                  "context": {
-                    "system": "context",
-                    "code": "context",
-                    "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "1",
-                    "display": ""
-                  }]
-                }]], "exclusionCriteria": [[{
-                  "context": {
-                    "system": "context",
-                    "code": "context",
-                    "display": "context"
-                  },
-                  "termCodes": [{
-                    "system": "tc",
-                    "code": "2",
-                    "display": ""
-                  }]
-                }]]}
-                """, StructuredQuery.class);
+        @Test
+        void multiClauseAnchorGroupIsAllowed() {
+            // AND-groups as anchors are supported (see Group's AnchorDates design note for how a dependent's
+            // window is computed asymmetrically across the anchor's clauses) - this is a regression guard against
+            // reintroducing the single-OR-clause-only restriction this used to have.
+            var anchor = Group.of("anchor", List.of(
+                    List.of(ConceptCriterion.of(ContextualConcept.of(TC_1))),
+                    List.of(ConceptCriterion.of(ContextualConcept.of(TC_2)))), Group.AnchorOccurrence.FIRST);
+            var dependent = Group.of("dependent", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                    RelativeTimeRestriction.of("anchor", Duration.ofHours(1), null));
 
-        assertEquals(ContextualConcept.of(TC_1), structuredQuery.inclusionCriteria().get(0).get(0).getConcept());
-        assertEquals(ContextualConcept.of(TC_2), structuredQuery.exclusionCriteria().get(0).get(0).getConcept());
+            assertDoesNotThrow(() -> StructuredQuery.of(List.of(anchor, dependent)));
+        }
+
+        @Test
+        void missingAnchorOccurrence() {
+            var anchor = Group.of("anchor", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))));
+            var dependent = Group.of("dependent", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_2)))),
+                    RelativeTimeRestriction.of("anchor", Duration.ofHours(1), null));
+
+            var message = assertThrows(IllegalArgumentException.class,
+                    () -> StructuredQuery.of(List.of(anchor, dependent))).getMessage();
+
+            assertEquals("Group `anchor` is used as an anchor and therefore requires `anchorOccurrence` to be set.",
+                    message);
+        }
+
+        @Test
+        void nowAnchorNeedsNoAnchorOccurrence() {
+            var anchor = Group.of("now-anchor", NowCriterion.INSTANCE);
+            var dependent = Group.of("dependent", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                    RelativeTimeRestriction.of("now-anchor", Duration.ofHours(-1), null));
+
+            StructuredQuery.of(List.of(anchor, dependent));
+        }
+
+        @Test
+        void anchorReferencedFromOtherSideOfDocument() {
+            var anchor = Group.of("anchor", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_1)))),
+                    Group.AnchorOccurrence.FIRST);
+            var dependentExclusion = Group.of("dependent", List.of(List.of(ConceptCriterion.of(ContextualConcept.of(TC_2)))),
+                    RelativeTimeRestriction.of("anchor", null, Duration.ofHours(1)));
+
+            StructuredQuery.of(List.of(anchor), List.of(dependentExclusion));
+        }
     }
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/DiagnosticReport/DiagnosticReportSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/DiagnosticReport/DiagnosticReportSQ.json
@@ -2,26 +2,30 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "Ausgewählte Merkmale",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "51969-4",
-            "display": "Genetic analysis report",
-            "system": "http://loinc.org"
+            "termCodes": [
+              {
+                "code": "51969-4",
+                "display": "Genetic analysis report",
+                "system": "http://loinc.org"
+              }
+            ],
+            "context": {
+              "code": "Molekulargenetischer Befundbericht",
+              "display": "Molekulargenetischer Befundbericht",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "timeRestriction": {
+              "afterDate": "2022-01-01",
+              "beforeDate": "2023-01-01"
+            }
           }
-        ],
-        "context": {
-          "code": "Molekulargenetischer Befundbericht",
-          "display": "Molekulargenetischer Befundbericht",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "timeRestriction": {
-          "afterDate": "2022-01-01",
-          "beforeDate": "2023-01-01"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatient.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatient.json
@@ -2,23 +2,27 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "Ausgewählte Merkmale",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "IMP",
-            "display": "inpatient encounter",
-            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-            "version": "9.0.0"
+            "termCodes": [
+              {
+                "code": "IMP",
+                "display": "inpatient encounter",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "version": "9.0.0"
+              }
+            ],
+            "context": {
+              "code": "Fall",
+              "display": "Fall",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Fall",
-          "display": "Fall",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatientAbteilung.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatientAbteilung.json
@@ -2,41 +2,45 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "Ausgewählte Merkmale",
   "inclusionCriteria": [
-    [
-      {
-        "attributeFilters": [
+    {
+      "criteria": [
+        [
           {
-            "selectedConcepts": [
+            "attributeFilters": [
               {
-                "code": "abteilungskontakt",
-                "display": "Abteilungskontakt",
-                "system": "http://fhir.de/CodeSystem/Kontaktebene",
-                "version": "2099"
+                "selectedConcepts": [
+                  {
+                    "code": "abteilungskontakt",
+                    "display": "Abteilungskontakt",
+                    "system": "http://fhir.de/CodeSystem/Kontaktebene",
+                    "version": "2099"
+                  }
+                ],
+                "type": "concept",
+                "attributeCode": {
+                  "code": "Kontaktebene",
+                  "display": "Kontaktebene",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                }
               }
             ],
-            "type": "concept",
-            "attributeCode": {
-              "code": "Kontaktebene",
-              "display": "Kontaktebene",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "termCodes": [
+              {
+                "code": "IMP",
+                "display": "inpatient encounter",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "version": "9.0.0"
+              }
+            ],
+            "context": {
+              "code": "Fall",
+              "display": "Fall",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
             }
           }
-        ],
-        "termCodes": [
-          {
-            "code": "IMP",
-            "display": "inpatient encounter",
-            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-            "version": "9.0.0"
-          }
-        ],
-        "context": {
-          "code": "Fall",
-          "display": "Fall",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatientEinrichtung.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatientEinrichtung.json
@@ -2,41 +2,45 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "Ausgewählte Merkmale",
   "inclusionCriteria": [
-    [
-      {
-        "attributeFilters": [
+    {
+      "criteria": [
+        [
           {
-            "selectedConcepts": [
+            "attributeFilters": [
               {
-                "code": "einrichtungskontakt",
-                "display": "Einrichtungskontakt",
-                "system": "http://fhir.de/CodeSystem/Kontaktebene",
-                "version": "2099"
+                "selectedConcepts": [
+                  {
+                    "code": "einrichtungskontakt",
+                    "display": "Einrichtungskontakt",
+                    "system": "http://fhir.de/CodeSystem/Kontaktebene",
+                    "version": "2099"
+                  }
+                ],
+                "type": "concept",
+                "attributeCode": {
+                  "code": "Kontaktebene",
+                  "display": "Kontaktebene",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                }
               }
             ],
-            "type": "concept",
-            "attributeCode": {
-              "code": "Kontaktebene",
-              "display": "Kontaktebene",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "termCodes": [
+              {
+                "code": "IMP",
+                "display": "inpatient encounter",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "version": "9.0.0"
+              }
+            ],
+            "context": {
+              "code": "Fall",
+              "display": "Fall",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
             }
           }
-        ],
-        "termCodes": [
-          {
-            "code": "IMP",
-            "display": "inpatient encounter",
-            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-            "version": "9.0.0"
-          }
-        ],
-        "context": {
-          "code": "Fall",
-          "display": "Fall",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatientEinrichtungTimeRestriction.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/EncounterInpatientEinrichtungTimeRestriction.json
@@ -2,45 +2,49 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "Ausgewählte Merkmale",
   "inclusionCriteria": [
-    [
-      {
-        "attributeFilters": [
+    {
+      "criteria": [
+        [
           {
-            "selectedConcepts": [
+            "attributeFilters": [
               {
-                "code": "einrichtungskontakt",
-                "display": "Einrichtungskontakt",
-                "system": "http://fhir.de/CodeSystem/Kontaktebene",
-                "version": "2099"
+                "selectedConcepts": [
+                  {
+                    "code": "einrichtungskontakt",
+                    "display": "Einrichtungskontakt",
+                    "system": "http://fhir.de/CodeSystem/Kontaktebene",
+                    "version": "2099"
+                  }
+                ],
+                "type": "concept",
+                "attributeCode": {
+                  "code": "Kontaktebene",
+                  "display": "Kontaktebene",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                }
               }
             ],
-            "type": "concept",
-            "attributeCode": {
-              "code": "Kontaktebene",
-              "display": "Kontaktebene",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "termCodes": [
+              {
+                "code": "IMP",
+                "display": "inpatient encounter",
+                "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
+                "version": "9.0.0"
+              }
+            ],
+            "context": {
+              "code": "Fall",
+              "display": "Fall",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "timeRestriction": {
+              "afterDate": "2024-01-01",
+              "beforeDate": "2024-02-15"
             }
           }
-        ],
-        "termCodes": [
-          {
-            "code": "IMP",
-            "display": "inpatient encounter",
-            "system": "http://terminology.hl7.org/CodeSystem/v3-ActCode",
-            "version": "9.0.0"
-          }
-        ],
-        "context": {
-          "code": "Fall",
-          "display": "Fall",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "timeRestriction": {
-          "afterDate": "2024-01-01",
-          "beforeDate": "2024-02-15"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQ.json
@@ -1,23 +1,27 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "display": "Verabreichung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "display": "Verabreichung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQDoubleCriteria.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQDoubleCriteria.json
@@ -1,49 +1,53 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "display": "Verabreichung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "display": "Verabreichung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ],
+            "timeRestriction": {
+              "beforeDate": "2024-02-01",
+              "afterDate": "2024-01-01"
+            }
           }
         ],
-        "timeRestriction": {
-          "beforeDate": "2024-02-01",
-          "afterDate": "2024-01-01"
-        }
-      }
-    ],
-    [
-      {
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "display": "Verabreichung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "display": "Verabreichung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ],
+            "timeRestriction": {
+              "beforeDate": "2023-02-01",
+              "afterDate": "2023-01-01"
+            }
           }
-        ],
-        "timeRestriction": {
-          "beforeDate": "2023-02-01",
-          "afterDate": "2023-01-01"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQTimeRestriction.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQTimeRestriction.json
@@ -1,27 +1,31 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "display": "Verabreichung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "display": "Verabreichung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ],
+            "timeRestriction": {
+              "beforeDate": "2024-02-01",
+              "afterDate": "2024-01-01"
+            }
           }
-        ],
-        "timeRestriction": {
-          "beforeDate": "2024-02-01",
-          "afterDate": "2024-01-01"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQTwoCriteria.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationAdministrationSQTwoCriteria.json
@@ -1,41 +1,45 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "display": "Verabreichung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "display": "Verabreichung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "display": "Verabreichung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AC06",
+                "display": "Acetylsalicylsäure",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2022"
+              }
+            ]
           }
         ]
-      }
-    ],
-    [
-      {
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "display": "Verabreichung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
-          {
-            "code": "B01AC06",
-            "display": "Acetylsalicyls\u00e4ure",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2022"
-          }
-        ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationRequestSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationRequestSQ.json
@@ -1,23 +1,27 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenanordnung",
-          "display": "Anordnung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenanordnung",
+              "display": "Anordnung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationRequestSQTimeRestriction.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationRequestSQTimeRestriction.json
@@ -1,27 +1,31 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenanordnung",
-          "display": "Anordnung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenanordnung",
+              "display": "Anordnung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ],
+            "timeRestriction": {
+              "beforeDate": "2024-02-01",
+              "afterDate": "2024-01-01"
+            }
           }
-        ],
-        "timeRestriction": {
-          "beforeDate": "2024-02-01",
-          "afterDate": "2024-01-01"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationStatementSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationStatementSQ.json
@@ -1,23 +1,27 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverordnung",
-          "display": "Verordnung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenverordnung",
+              "display": "Verordnung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationStatementSQTimeRestriction.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/MedicationStatementSQTimeRestriction.json
@@ -1,27 +1,31 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverordnung",
-          "display": "Verordnung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "B01AB01",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2021",
-            "display": "Enoxaparin natrium"
+            "context": {
+              "code": "Medikamentenverordnung",
+              "display": "Verordnung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "B01AB01",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2021",
+                "display": "Enoxaparin natrium"
+              }
+            ],
+            "timeRestriction": {
+              "beforeDate": "2024-02-01",
+              "afterDate": "2024-01-01"
+            }
           }
-        ],
-        "timeRestriction": {
-          "beforeDate": "2024-02-01",
-          "afterDate": "2024-01-01"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/NoSearchPathSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/NoSearchPathSQ.json
@@ -2,23 +2,27 @@
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema#",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "2.16.840.1.113883.3.1937.777.24.5.3.6",
-            "display": "MDAT erheben",
-            "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3",
-            "version": "1.0.2"
+            "termCodes": [
+              {
+                "code": "2.16.840.1.113883.3.1937.777.24.5.3.6",
+                "display": "MDAT erheben",
+                "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3",
+                "version": "1.0.2"
+              }
+            ],
+            "context": {
+              "code": "Einwilligung",
+              "display": "Einwilligung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Einwilligung",
-          "display": "Einwilligung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/NonPrimarySearchPathSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/NonPrimarySearchPathSQ.json
@@ -1,23 +1,27 @@
 {
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "387713003",
-            "display": "Surgical procedure",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20230731"
+            "termCodes": [
+              {
+                "code": "387713003",
+                "display": "Surgical procedure",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20230731"
+              }
+            ],
+            "context": {
+              "code": "Procedure Category",
+              "display": "Prozedurenkategorie",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Procedure Category",
-          "display": "Prozedurenkategorie",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/PrimaryPathSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/PrimaryPathSQ.json
@@ -2,23 +2,27 @@
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "726427004",
-            "display": "Lobectomy of upper lobe of left lung",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20230731"
+            "termCodes": [
+              {
+                "code": "726427004",
+                "display": "Lobectomy of upper lobe of left lung",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20230731"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "display": "Prozedur",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Procedure",
-          "display": "Prozedur",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQ.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQ.json
@@ -2,51 +2,55 @@
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Specimen",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Bioprobe"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "119364003",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20220930",
-            "display": "Serum specimen"
-          }
-        ],
-        "attributeFilters": [
-          {
-            "type": "reference",
-            "attributeCode": {
-              "code": "festgestellteDiagnose",
-              "display": "Festgestellte Diagnose",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "context": {
+              "code": "Specimen",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Bioprobe"
             },
-            "criteria": [
+            "termCodes": [
               {
-                "termCodes": [
+                "code": "119364003",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20220930",
+                "display": "Serum specimen"
+              }
+            ],
+            "attributeFilters": [
+              {
+                "type": "reference",
+                "attributeCode": {
+                  "code": "festgestellteDiagnose",
+                  "display": "Festgestellte Diagnose",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                },
+                "criteria": [
                   {
-                    "code": "E13.9",
-                    "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-                    "version": "2023",
-                    "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                    "termCodes": [
+                      {
+                        "code": "E13.9",
+                        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                        "version": "2023",
+                        "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                      }
+                    ],
+                    "context": {
+                      "code": "Diagnose",
+                      "system": "fdpg.mii.cds",
+                      "version": "1.0.0",
+                      "display": "Diagnose"
+                    }
                   }
-                ],
-                "context": {
-                  "code": "Diagnose",
-                  "system": "fdpg.mii.cds",
-                  "version": "1.0.0",
-                  "display": "Diagnose"
-                }
+                ]
               }
             ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQAndBodySite.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQAndBodySite.json
@@ -2,66 +2,70 @@
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Specimen",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Bioprobe"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "119364003",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20220930",
-            "display": "Serum specimen"
-          }
-        ],
-        "attributeFilters": [
-          {
-            "type": "reference",
-            "attributeCode": {
-              "code": "festgestellteDiagnose",
-              "display": "Festgestellte Diagnose",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "context": {
+              "code": "Specimen",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Bioprobe"
             },
-            "criteria": [
+            "termCodes": [
               {
-                "termCodes": [
-                  {
-                    "code": "E13.9",
-                    "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-                    "version": "2023",
-                    "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
-                  }
-                ],
-                "context": {
-                  "code": "Diagnose",
-                  "system": "fdpg.mii.cds",
-                  "version": "1.0.0",
-                  "display": "Diagnose"
-                }
+                "code": "119364003",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20220930",
+                "display": "Serum specimen"
               }
-            ]
-          },
-          {
-            "type": "concept",
-            "attributeCode": {
-              "code": "icd-o-3",
-              "display": "icd-o-3",
-              "system": "http://hl7.org/fhir/StructureDefinition"
-            },
-            "selectedConcepts": [
+            ],
+            "attributeFilters": [
               {
-                "code": "C44.6",
-                "system": "urn:oid:2.16.840.1.113883.6.43.1",
-                "display": "Haut der oberen Extremitäten und der Schulter"
+                "type": "reference",
+                "attributeCode": {
+                  "code": "festgestellteDiagnose",
+                  "display": "Festgestellte Diagnose",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                },
+                "criteria": [
+                  {
+                    "termCodes": [
+                      {
+                        "code": "E13.9",
+                        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                        "version": "2023",
+                        "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                      }
+                    ],
+                    "context": {
+                      "code": "Diagnose",
+                      "system": "fdpg.mii.cds",
+                      "version": "1.0.0",
+                      "display": "Diagnose"
+                    }
+                  }
+                ]
+              },
+              {
+                "type": "concept",
+                "attributeCode": {
+                  "code": "icd-o-3",
+                  "display": "icd-o-3",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                },
+                "selectedConcepts": [
+                  {
+                    "code": "C44.6",
+                    "system": "urn:oid:2.16.840.1.113883.6.43.1",
+                    "display": "Haut der oberen Extremitäten und der Schulter"
+                  }
+                ]
               }
             ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQExclusion.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQExclusion.json
@@ -2,80 +2,88 @@
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Patient",
-          "display": "Patient",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "263495000",
-            "display": "Geschlecht",
-            "system": "http://snomed.info/sct"
-          }
-        ],
-        "valueFilter": {
-          "type": "concept",
-          "selectedConcepts": [
-            {
-              "code": "female",
-              "system": "http://hl7.org/fhir/administrative-gender",
-              "display": "Female"
+            "context": {
+              "code": "Patient",
+              "display": "Patient",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "263495000",
+                "display": "Geschlecht",
+                "system": "http://snomed.info/sct"
+              }
+            ],
+            "valueFilter": {
+              "type": "concept",
+              "selectedConcepts": [
+                {
+                  "code": "female",
+                  "system": "http://hl7.org/fhir/administrative-gender",
+                  "display": "Female"
+                }
+              ]
             }
-          ]
-        }
-      }
-    ]
+          }
+        ]
+      ]
+    }
   ],
   "exclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Specimen",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Bioprobe"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "119364003",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20220930",
-            "display": "Serum specimen"
-          }
-        ],
-        "attributeFilters": [
-          {
-            "type": "reference",
-            "attributeCode": {
-              "code": "festgestellteDiagnose",
-              "display": "Festgestellte Diagnose",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "context": {
+              "code": "Specimen",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Bioprobe"
             },
-            "criteria": [
+            "termCodes": [
               {
-                "termCodes": [
+                "code": "119364003",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20220930",
+                "display": "Serum specimen"
+              }
+            ],
+            "attributeFilters": [
+              {
+                "type": "reference",
+                "attributeCode": {
+                  "code": "festgestellteDiagnose",
+                  "display": "Festgestellte Diagnose",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                },
+                "criteria": [
                   {
-                    "code": "E13.9",
-                    "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-                    "version": "2023",
-                    "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                    "termCodes": [
+                      {
+                        "code": "E13.9",
+                        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                        "version": "2023",
+                        "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                      }
+                    ],
+                    "context": {
+                      "code": "Diagnose",
+                      "system": "fdpg.mii.cds",
+                      "version": "1.0.0",
+                      "display": "Diagnose"
+                    }
                   }
-                ],
-                "context": {
-                  "code": "Diagnose",
-                  "system": "fdpg.mii.cds",
-                  "version": "1.0.0",
-                  "display": "Diagnose"
-                }
+                ]
               }
             ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQTwoInclusion.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQTwoInclusion.json
@@ -2,78 +2,82 @@
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Patient",
-          "display": "Patient",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "263495000",
-            "display": "Geschlecht",
-            "system": "http://snomed.info/sct"
-          }
-        ],
-        "valueFilter": {
-          "type": "concept",
-          "selectedConcepts": [
-            {
-              "code": "female",
-              "system": "http://hl7.org/fhir/administrative-gender",
-              "display": "Female"
-            }
-          ]
-        }
-      }
-    ],
-    [
-      {
-        "context": {
-          "code": "Specimen",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Bioprobe"
-        },
-        "termCodes": [
-          {
-            "code": "119364003",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20220930",
-            "display": "Serum specimen"
-          }
-        ],
-        "attributeFilters": [
-          {
-            "type": "reference",
-            "attributeCode": {
-              "code": "festgestellteDiagnose",
-              "display": "Festgestellte Diagnose",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "context": {
+              "code": "Patient",
+              "display": "Patient",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
             },
-            "criteria": [
+            "termCodes": [
               {
-                "termCodes": [
-                  {
-                    "code": "E13.9",
-                    "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-                    "version": "2023",
-                    "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
-                  }
-                ],
-                "context": {
-                  "code": "Diagnose",
-                  "system": "fdpg.mii.cds",
-                  "version": "1.0.0",
-                  "display": "Diagnose"
+                "code": "263495000",
+                "display": "Geschlecht",
+                "system": "http://snomed.info/sct"
+              }
+            ],
+            "valueFilter": {
+              "type": "concept",
+              "selectedConcepts": [
+                {
+                  "code": "female",
+                  "system": "http://hl7.org/fhir/administrative-gender",
+                  "display": "Female"
                 }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "context": {
+              "code": "Specimen",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Bioprobe"
+            },
+            "termCodes": [
+              {
+                "code": "119364003",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20220930",
+                "display": "Serum specimen"
+              }
+            ],
+            "attributeFilters": [
+              {
+                "type": "reference",
+                "attributeCode": {
+                  "code": "festgestellteDiagnose",
+                  "display": "Festgestellte Diagnose",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                },
+                "criteria": [
+                  {
+                    "termCodes": [
+                      {
+                        "code": "E13.9",
+                        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                        "version": "2023",
+                        "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                      }
+                    ],
+                    "context": {
+                      "code": "Diagnose",
+                      "system": "fdpg.mii.cds",
+                      "version": "1.0.0",
+                      "display": "Diagnose"
+                    }
+                  }
+                ]
               }
             ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQTwoReferenceCriteria.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/SpecimenSQTwoReferenceCriteria.json
@@ -2,67 +2,71 @@
   "version": "https://medizininformatik-initiative.de/fdpg/StructuredQuery/v3/schema",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Specimen",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Bioprobe"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "119364003",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20220930",
-            "display": "Serum specimen"
-          }
-        ],
-        "attributeFilters": [
-          {
-            "type": "reference",
-            "attributeCode": {
-              "code": "festgestellteDiagnose",
-              "display": "Festgestellte Diagnose",
-              "system": "http://hl7.org/fhir/StructureDefinition"
+            "context": {
+              "code": "Specimen",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Bioprobe"
             },
-            "criteria": [
+            "termCodes": [
               {
-                "termCodes": [
-                  {
-                    "code": "E13.9",
-                    "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-                    "version": "2023",
-                    "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
-                  }
-                ],
-                "context": {
-                  "code": "Diagnose",
-                  "system": "fdpg.mii.cds",
-                  "version": "1.0.0",
-                  "display": "Diagnose"
-                }
-              },
+                "code": "119364003",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20220930",
+                "display": "Serum specimen"
+              }
+            ],
+            "attributeFilters": [
               {
-                "termCodes": [
+                "type": "reference",
+                "attributeCode": {
+                  "code": "festgestellteDiagnose",
+                  "display": "Festgestellte Diagnose",
+                  "system": "http://hl7.org/fhir/StructureDefinition"
+                },
+                "criteria": [
                   {
-                    "code": "E13.1",
-                    "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-                    "version": "2023",
-                    "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                    "termCodes": [
+                      {
+                        "code": "E13.9",
+                        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                        "version": "2023",
+                        "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                      }
+                    ],
+                    "context": {
+                      "code": "Diagnose",
+                      "system": "fdpg.mii.cds",
+                      "version": "1.0.0",
+                      "display": "Diagnose"
+                    }
+                  },
+                  {
+                    "termCodes": [
+                      {
+                        "code": "E13.1",
+                        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                        "version": "2023",
+                        "display": "Sonstiger näher bezeichneter Diabetes mellitus : Ohne Komplikationen"
+                      }
+                    ],
+                    "context": {
+                      "code": "Diagnose",
+                      "system": "fdpg.mii.cds",
+                      "version": "1.0.0",
+                      "display": "Diagnose"
+                    }
                   }
-                ],
-                "context": {
-                  "code": "Diagnose",
-                  "system": "fdpg.mii.cds",
-                  "version": "1.0.0",
-                  "display": "Diagnose"
-                }
+                ]
               }
             ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/consent.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/consent.json
@@ -2,22 +2,26 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Einwilligung",
-          "display": "Einwilligung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "2.16.840.1.113883.3.1937.777.24.5.3.8",
-            "display": "MDAT wissenschaftlich nutzen EU DSGVO NIVEAU",
-            "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3"
+            "context": {
+              "code": "Einwilligung",
+              "display": "Einwilligung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "2.16.840.1.113883.3.1937.777.24.5.3.8",
+                "display": "MDAT wissenschaftlich nutzen EU DSGVO NIVEAU",
+                "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3"
+              }
+            ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/example-all-crits-time.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/example-all-crits-time.json
@@ -2,263 +2,267 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "2.16.840.1.113883.3.1937.777.24.5.3.23",
-            "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3",
-            "version": "1.0.2",
-            "display": "BIOMAT Analysedaten zusammenfuehren Dritte"
-          }
-        ],
-        "context": {
-          "code": "Einwilligung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Einwilligung"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "119373006",
-            "system": "http://snomed.info/sct",
-            "version": "http://snomed.info/sct/900000000000207008/version/20220930",
-            "display": "Amniotic fluid specimen"
-          }
-        ],
-        "attributeFilters": [
-          {
-            "type": "reference",
-            "criteria": [
+            "termCodes": [
               {
-                "termCodes": [
+                "code": "2.16.840.1.113883.3.1937.777.24.5.3.23",
+                "system": "urn:oid:2.16.840.1.113883.3.1937.777.24.5.3",
+                "version": "1.0.2",
+                "display": "BIOMAT Analysedaten zusammenfuehren Dritte"
+              }
+            ],
+            "context": {
+              "code": "Einwilligung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Einwilligung"
+            }
+          }
+        ],
+        [
+          {
+            "termCodes": [
+              {
+                "code": "119373006",
+                "system": "http://snomed.info/sct",
+                "version": "http://snomed.info/sct/900000000000207008/version/20220930",
+                "display": "Amniotic fluid specimen"
+              }
+            ],
+            "attributeFilters": [
+              {
+                "type": "reference",
+                "criteria": [
                   {
-                    "code": "C50.0",
-                    "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-                    "version": "2023",
-                    "display": "Brustwarze und Warzenhof"
+                    "termCodes": [
+                      {
+                        "code": "C50.0",
+                        "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                        "version": "2023",
+                        "display": "Brustwarze und Warzenhof"
+                      }
+                    ],
+                    "context": {
+                      "code": "Diagnose",
+                      "system": "fdpg.mii.cds",
+                      "version": "1.0.0",
+                      "display": "Diagnose"
+                    }
                   }
                 ],
-                "context": {
-                  "code": "Diagnose",
-                  "system": "fdpg.mii.cds",
-                  "version": "1.0.0",
-                  "display": "Diagnose"
+                "attributeCode": {
+                  "code": "festgestellteDiagnose",
+                  "system": "http://hl7.org/fhir/StructureDefinition",
+                  "display": "Festgestellte Diagnose"
+                }
+              },
+              {
+                "type": "concept",
+                "selectedConcepts": [
+                  {
+                    "code": "C76.2",
+                    "system": "http://hl7.org/fhir/sid/icd-o-3",
+                    "display": "Abdomen o.n.A."
+                  },
+                  {
+                    "code": "C24.1",
+                    "system": "http://hl7.org/fhir/sid/icd-o-3",
+                    "display": "Ampulla Vateri"
+                  }
+                ],
+                "attributeCode": {
+                  "code": "icd-o-3",
+                  "system": "http://hl7.org/fhir/StructureDefinition",
+                  "display": "icd-o-3"
                 }
               }
             ],
-            "attributeCode": {
-              "code": "festgestellteDiagnose",
-              "system": "http://hl7.org/fhir/StructureDefinition",
-              "display": "Festgestellte Diagnose"
+            "context": {
+              "code": "Specimen",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Bioprobe"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-30",
+              "afterDate": "2023-11-06"
             }
-          },
+          }
+        ],
+        [
           {
-            "type": "concept",
-            "selectedConcepts": [
+            "termCodes": [
               {
-                "code": "C76.2",
-                "system": "http://hl7.org/fhir/sid/icd-o-3",
-                "display": "Abdomen o.n.A."
-              },
-              {
-                "code": "C24.1",
-                "system": "http://hl7.org/fhir/sid/icd-o-3",
-                "display": "Ampulla Vateri"
+                "code": "E13",
+                "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
+                "version": "2023",
+                "display": "Sonstiger näher bezeichneter Diabetes mellitus"
               }
             ],
-            "attributeCode": {
-              "code": "icd-o-3",
-              "system": "http://hl7.org/fhir/StructureDefinition",
-              "display": "icd-o-3"
+            "context": {
+              "code": "Diagnose",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Diagnose"
             }
           }
         ],
-        "context": {
-          "code": "Specimen",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Bioprobe"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-30",
-          "afterDate": "2023-11-06"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
+        [
           {
-            "code": "E13",
-            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm",
-            "version": "2023",
-            "display": "Sonstiger näher bezeichneter Diabetes mellitus"
-          }
-        ],
-        "context": {
-          "code": "Diagnose",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Diagnose"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "718-7",
-            "system": "http://loinc.org",
-            "display": "Hämoglobin"
-          }
-        ],
-        "context": {
-          "code": "Laboruntersuchung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Laboruntersuchung"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "718-7",
-            "system": "http://loinc.org",
-            "display": "Hämoglobin"
-          }
-        ],
-        "context": {
-          "code": "Laboruntersuchung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Laboruntersuchung"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-13",
-          "afterDate": "2023-11-13"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "A14AA50",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2022",
-            "display": "Andere Androstan-Derivate, Kombinationen"
-          }
-        ],
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Verabreichung von Medikamenten"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-22",
-          "afterDate": "2023-11-05"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "A14AA08",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc",
-            "version": "2022",
-            "display": "Oxandrolon"
-          }
-        ],
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Verabreichung von Medikamenten"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "424144002",
-            "system": "http://snomed.info/sct",
-            "display": "Gegenwärtiges chronologisches Alter"
-          }
-        ],
-        "context": {
-          "code": "Patient",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Patient"
-        },
-        "valueFilter": {
-          "type": "quantity-comparator",
-          "unit": {
-            "code": "a",
-            "display": "a"
-          },
-          "value": 20,
-          "comparator": "eq"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "263495000",
-            "system": "http://snomed.info/sct",
-            "display": "Geschlecht"
-          }
-        ],
-        "context": {
-          "code": "Patient",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Patient"
-        },
-        "valueFilter": {
-          "type": "concept",
-          "selectedConcepts": [
-            {
-              "code": "female",
-              "system": "http://hl7.org/fhir/administrative-gender",
-              "display": "Female"
+            "termCodes": [
+              {
+                "code": "718-7",
+                "system": "http://loinc.org",
+                "display": "Hämoglobin"
+              }
+            ],
+            "context": {
+              "code": "Laboruntersuchung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Laboruntersuchung"
             }
-          ]
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "3-901",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Elektroimpedanzspektroskopie der Haut"
           }
         ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-22"
-        }
-      }
-    ]
+        [
+          {
+            "termCodes": [
+              {
+                "code": "718-7",
+                "system": "http://loinc.org",
+                "display": "Hämoglobin"
+              }
+            ],
+            "context": {
+              "code": "Laboruntersuchung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Laboruntersuchung"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-13",
+              "afterDate": "2023-11-13"
+            }
+          }
+        ],
+        [
+          {
+            "termCodes": [
+              {
+                "code": "A14AA50",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2022",
+                "display": "Andere Androstan-Derivate, Kombinationen"
+              }
+            ],
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Verabreichung von Medikamenten"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-22",
+              "afterDate": "2023-11-05"
+            }
+          }
+        ],
+        [
+          {
+            "termCodes": [
+              {
+                "code": "A14AA08",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc",
+                "version": "2022",
+                "display": "Oxandrolon"
+              }
+            ],
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Verabreichung von Medikamenten"
+            }
+          }
+        ],
+        [
+          {
+            "termCodes": [
+              {
+                "code": "424144002",
+                "system": "http://snomed.info/sct",
+                "display": "Gegenwärtiges chronologisches Alter"
+              }
+            ],
+            "context": {
+              "code": "Patient",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Patient"
+            },
+            "valueFilter": {
+              "type": "quantity-comparator",
+              "unit": {
+                "code": "a",
+                "display": "a"
+              },
+              "value": 20,
+              "comparator": "eq"
+            }
+          }
+        ],
+        [
+          {
+            "termCodes": [
+              {
+                "code": "263495000",
+                "system": "http://snomed.info/sct",
+                "display": "Geschlecht"
+              }
+            ],
+            "context": {
+              "code": "Patient",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Patient"
+            },
+            "valueFilter": {
+              "type": "concept",
+              "selectedConcepts": [
+                {
+                  "code": "female",
+                  "system": "http://hl7.org/fhir/administrative-gender",
+                  "display": "Female"
+                }
+              ]
+            }
+          }
+        ],
+        [
+          {
+            "termCodes": [
+              {
+                "code": "3-901",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Elektroimpedanzspektroskopie der Haut"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-22"
+            }
+          }
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/large-query-worst-case-with-time-constraints.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/large-query-worst-case-with-time-constraints.json
@@ -2,68 +2,76 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "8-810",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Transfusion von Plasmabestandteilen und gentechnisch hergestellten Plasmaproteinen"
+            "termCodes": [
+              {
+                "code": "8-810",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Transfusion von Plasmabestandteilen und gentechnisch hergestellten Plasmaproteinen"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-11",
+              "afterDate": "2023-11-05"
+            }
           }
         ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-11",
-          "afterDate": "2023-11-05"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
+        [
           {
-            "code": "5-39",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Andere Operationen an Blutgefäßen und Zusatzinformationen zu Operationen an Blutgefäßen"
+            "termCodes": [
+              {
+                "code": "5-39",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Andere Operationen an Blutgefäßen und Zusatzinformationen zu Operationen an Blutgefäßen"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            }
           }
-        ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ],
   "exclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "5-45",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Inzision, Exzision, Resektion und Anastomose an Dünn- und Dickdarm"
+            "termCodes": [
+              {
+                "code": "5-45",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Inzision, Exzision, Resektion und Anastomose an Dünn- und Dickdarm"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-13"
+            }
           }
-        ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-13"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Consent.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Consent.json
@@ -2,22 +2,26 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "Ausgewählte Merkmale",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "yes-yes-no-no",
-            "display": "Verteilte, EU-DSGVO konforme Analyse, ohne Krankenkassendaten, und ohne Rekontaktierung",
-            "system": "fdpg.consent.combined"
+            "termCodes": [
+              {
+                "code": "yes-yes-no-no",
+                "display": "Verteilte, EU-DSGVO konforme Analyse, ohne Krankenkassendaten, und ohne Rekontaktierung",
+                "system": "fdpg.consent.combined"
+              }
+            ],
+            "context": {
+              "code": "Einwilligung",
+              "display": "Einwilligung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Einwilligung",
-          "display": "Einwilligung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Diagnose-TimeRestriction.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Diagnose-TimeRestriction.json
@@ -1,26 +1,30 @@
 {
   "version": "http://to_be_decided.com/draft-1/schema#",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Diagnose",
-          "display": "Diagnose",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "S14.11",
-            "display": "",
-            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm"
+            "context": {
+              "code": "Diagnose",
+              "display": "Diagnose",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "S14.11",
+                "display": "",
+                "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm"
+              }
+            ],
+            "timeRestriction": {
+              "afterDate": "2023-02-01",
+              "beforeDate": "2023-02-28"
+            }
           }
-        ],
-        "timeRestriction": {
-          "afterDate": "2023-02-01",
-          "beforeDate": "2023-02-28"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Diagnose.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Diagnose.json
@@ -1,23 +1,27 @@
 {
   "version": "http://to_be_decided.com/draft-1/schema#",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Diagnose",
-          "display": "Diagnose",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "I08.0",
-            "display": "",
-            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm"
+            "context": {
+              "code": "Diagnose",
+              "display": "Diagnose",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "I08.0",
+                "display": "",
+                "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm"
+              }
+            ],
+            "attributeFilters": []
           }
-        ],
-        "attributeFilters": []
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/MedicationAdministration.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/MedicationAdministration.json
@@ -1,22 +1,26 @@
 {
   "version": "http://to_be_decided.com/draft-1/schema#",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverabreichung",
-          "display": "Verabreichung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "P01CA",
-            "display": "",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc"
+            "context": {
+              "code": "Medikamentenverabreichung",
+              "display": "Verabreichung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "P01CA",
+                "display": "",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc"
+              }
+            ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/MedicationRequest.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/MedicationRequest.json
@@ -1,22 +1,26 @@
 {
   "version": "http://to_be_decided.com/draft-1/schema#",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenanordnung",
-          "display": "Anordnung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "P01CA",
-            "display": "",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc"
+            "context": {
+              "code": "Medikamentenanordnung",
+              "display": "Anordnung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "P01CA",
+                "display": "",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc"
+              }
+            ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/MedicationStatement.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/MedicationStatement.json
@@ -1,22 +1,26 @@
 {
   "version": "http://to_be_decided.com/draft-1/schema#",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Medikamentenverordnung",
-          "display": "Verordnung von Medikamenten",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "P01CA",
-            "display": "",
-            "system": "http://fhir.de/CodeSystem/bfarm/atc"
+            "context": {
+              "code": "Medikamentenverordnung",
+              "display": "Verordnung von Medikamenten",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "P01CA",
+                "display": "",
+                "system": "http://fhir.de/CodeSystem/bfarm/atc"
+              }
+            ]
           }
         ]
-      }
-    ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/ObservationLab-TimeRestriction.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/ObservationLab-TimeRestriction.json
@@ -1,26 +1,30 @@
 {
   "version": "http://to_be_decided.com/draft-1/schema#",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Laboruntersuchung",
-          "display": "Laboruntersuchung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "800-3",
-            "display": "",
-            "system": "http://loinc.org"
+            "context": {
+              "code": "Laboruntersuchung",
+              "display": "Laboruntersuchung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "800-3",
+                "display": "",
+                "system": "http://loinc.org"
+              }
+            ],
+            "timeRestriction": {
+              "afterDate": "2004-07-24",
+              "beforeDate": "2004-07-24"
+            }
           }
-        ],
-        "timeRestriction": {
-          "afterDate": "2004-07-24",
-          "beforeDate": "2004-07-24"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/ObservationLab.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/ObservationLab.json
@@ -1,23 +1,27 @@
 {
   "version": "http://to_be_decided.com/draft-1/schema#",
   "inclusionCriteria": [
-    [
-      {
-        "context": {
-          "code": "Laboruntersuchung",
-          "display": "Laboruntersuchung",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        },
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "800-3",
-            "display": "",
-            "system": "http://loinc.org"
+            "context": {
+              "code": "Laboruntersuchung",
+              "display": "Laboruntersuchung",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            },
+            "termCodes": [
+              {
+                "code": "800-3",
+                "display": "",
+                "system": "http://loinc.org"
+              }
+            ],
+            "attributeFilters": []
           }
-        ],
-        "attributeFilters": []
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Procedure.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Procedure.json
@@ -1,23 +1,27 @@
 {
   "inclusionCriteria": [
-    [
-      {
-        "attributeFilters": [],
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "5-403.05",
-            "display": "",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops"
+            "attributeFilters": [],
+            "termCodes": [
+              {
+                "code": "5-403.05",
+                "display": "",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "display": "Prozedur",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Procedure",
-          "display": "Prozedur",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ],
   "version": "http://to_be_decided.com/draft-1/schema#"
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Specimen.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Specimen.json
@@ -1,23 +1,27 @@
 {
   "inclusionCriteria": [
-    [
-      {
-        "attributeFilters": [],
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "396997002",
-            "display": "",
-            "system": "http://snomed.info/sct"
+            "attributeFilters": [],
+            "termCodes": [
+              {
+                "code": "396997002",
+                "display": "",
+                "system": "http://snomed.info/sct"
+              }
+            ],
+            "context": {
+              "code": "Specimen",
+              "display": "Bioprobe",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Specimen",
-          "display": "Bioprobe",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ],
   "version": "http://to_be_decided.com/draft-1/schema#"
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Todesursache.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/returningOnePatient/Todesursache.json
@@ -1,23 +1,27 @@
 {
   "inclusionCriteria": [
-    [
-      {
-        "attributeFilters": [],
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "S14.11",
-            "display": "",
-            "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm"
+            "attributeFilters": [],
+            "termCodes": [
+              {
+                "code": "S14.11",
+                "display": "",
+                "system": "http://fhir.de/CodeSystem/bfarm/icd-10-gm"
+              }
+            ],
+            "context": {
+              "code": "Diagnose",
+              "display": "Diagnose",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0"
+            }
           }
-        ],
-        "context": {
-          "code": "Diagnose",
-          "display": "Diagnose",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ],
   "version": "http://to_be_decided.com/draft-1/schema#"
 }

--- a/cql/src/test/resources/de/medizininformatikinitiative/cctb/test-large-query-more-crit-time-rest-1.json
+++ b/cql/src/test/resources/de/medizininformatikinitiative/cctb/test-large-query-more-crit-time-rest-1.json
@@ -2,154 +2,162 @@
   "version": "http://to_be_decided.com/draft-1/schema#",
   "display": "",
   "inclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "8-810",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Transfusion von Plasmabestandteilen und gentechnisch hergestellten Plasmaproteinen"
+            "termCodes": [
+              {
+                "code": "8-810",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Transfusion von Plasmabestandteilen und gentechnisch hergestellten Plasmaproteinen"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-11",
+              "afterDate": "2023-11-05"
+            }
+          },
+          {
+            "termCodes": [
+              {
+                "code": "5-39",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Andere Operationen an Blutgefäßen und Zusatzinformationen zu Operationen an Blutgefäßen"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            }
           }
         ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-11",
-          "afterDate": "2023-11-05"
-        }
-      },
-      {
-        "termCodes": [
+        [
           {
-            "code": "5-39",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Andere Operationen an Blutgefäßen und Zusatzinformationen zu Operationen an Blutgefäßen"
+            "termCodes": [
+              {
+                "code": "6-002",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Applikation von Medikamenten, Liste 2"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            }
           }
         ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
+        [
           {
-            "code": "6-002",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Applikation von Medikamenten, Liste 2"
+            "termCodes": [
+              {
+                "code": "5-32",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Exzision und Resektion an Lunge und Bronchus"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            }
           }
         ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
+        [
           {
-            "code": "5-32",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Exzision und Resektion an Lunge und Bronchus"
+            "termCodes": [
+              {
+                "code": "5-800",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Offen chirurgische Operation eines Gelenkes"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            }
           }
-        ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
-          {
-            "code": "5-800",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Offen chirurgische Operation eines Gelenkes"
-          }
-        ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ],
   "exclusionCriteria": [
-    [
-      {
-        "termCodes": [
+    {
+      "criteria": [
+        [
           {
-            "code": "5-45",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Inzision, Exzision, Resektion und Anastomose an Dünn- und Dickdarm"
+            "termCodes": [
+              {
+                "code": "5-45",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Inzision, Exzision, Resektion und Anastomose an Dünn- und Dickdarm"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            },
+            "timeRestriction": {
+              "beforeDate": "2023-11-13"
+            }
           }
         ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        },
-        "timeRestriction": {
-          "beforeDate": "2023-11-13"
-        }
-      }
-    ],
-    [
-      {
-        "termCodes": [
+        [
           {
-            "code": "5-780",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Inzision am Knochen, septisch und aseptisch"
-          }
-        ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        }
-      },
-      {
-        "termCodes": [
+            "termCodes": [
+              {
+                "code": "5-780",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Inzision am Knochen, septisch und aseptisch"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            }
+          },
           {
-            "code": "5-781",
-            "system": "http://fhir.de/CodeSystem/bfarm/ops",
-            "version": "2023",
-            "display": "Osteotomie und Korrekturosteotomie"
+            "termCodes": [
+              {
+                "code": "5-781",
+                "system": "http://fhir.de/CodeSystem/bfarm/ops",
+                "version": "2023",
+                "display": "Osteotomie und Korrekturosteotomie"
+              }
+            ],
+            "context": {
+              "code": "Procedure",
+              "system": "fdpg.mii.cds",
+              "version": "1.0.0",
+              "display": "Prozedur"
+            }
           }
-        ],
-        "context": {
-          "code": "Procedure",
-          "system": "fdpg.mii.cds",
-          "version": "1.0.0",
-          "display": "Prozedur"
-        }
-      }
-    ]
+        ]
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Extends CCDL translation with anchor-relative time windows: a group of criteria can be dated relative to another group's resolved date instead of only via absolute afterDate/beforeDate.

- StructuredQuery.inclusionCriteria/exclusionCriteria move from List<List<Criterion>> to List<Group>, where a Group carries an id, a relativeTimeRestriction (anchorRef + minOffset/maxOffset), and anchorOccurrence/anchorPoint for when it's used as an anchor. Breaking change, no dual-format support.
- Add the `now` criterion for anchoring relative to the evaluation date.
- Resolve an anchor's date via Min/Max aggregation over its matching resources, hoisted into one named CQL definition and referenced by identifier from both bounds instead of duplicating the (potentially large, concept-expanded) subquery per bound.
- Support AND-groups as anchors: each clause resolves its own date independently, then the dependent's maxOffset bound is computed from the earliest clause and its minOffset bound from the latest - collapsing to a single anchor point gets one of the two bounds wrong.
- Fix InvocationExpression printing to parenthesize a lower-precedence base (e.g. `(x as Period).start`, not `x as Period.start`, which a CQL parser reads as an invalid qualified type name).
- Fix a Coalesce type mismatch (System.Date vs FHIR.dateTime) for mappings supporting both a dateTime-family type and Period - Blaze rejected the library outright before this fix.

Migrate all existing tests/fixtures to the Group-based shape.